### PR TITLE
feat: link channels page Create Agent button to agent designer

### DIFF
--- a/admin/src/pages/ChannelsPage.tsx
+++ b/admin/src/pages/ChannelsPage.tsx
@@ -732,10 +732,10 @@ export const ChannelsPage = () => {
               </p>
               <button
                 className="admin-button admin-button-primary mt-4"
-                onClick={() => void navigate('/settings#agents')}
+                onClick={() => void navigate('/agents/new')}
                 type="button"
               >
-                Open admin controls
+                Create agent
               </button>
             </div>
           </div>


### PR DESCRIPTION
## Summary

- Changes the "Open admin controls" button in the channels page Agents tab to "Create agent"
- Routes to `/agents/new` (the AgentDesignerPage / tool studio) instead of `/settings#agents`

## Test plan

- [ ] Navigate to `/channels`, open the Agents tab
- [ ] Verify the button now reads "Create agent"
- [ ] Click it — confirm it navigates to `/agents/new` (AgentDesignerPage)

🤖 Generated with [Claude Code](https://claude.ai/claude-code)