### PR TITLE
fix: prevent socket leaks in streaming HTTP responses via FinalizationRegistry

### DIFF
--- a/packages/runtime/src/inference/connectors.ts
+++ b/packages/runtime/src/inference/connectors.ts
@@ -182,6 +182,17 @@ const providerError = (input: {
   )
 }
 
+// Safety net: if a streaming response is abandoned and the generator is GC'd
+// before completion, FinalizationRegistry ensures the reader is cancelled and
+// released back to the connection pool, preventing socket leaks.
+// See: openclaw/openclaw#67461
+const streamFinalizationRegistry = new FinalizationRegistry<ReadableStreamDefaultReader>(
+  (reader) => {
+    reader.cancel().catch(() => { /* ignore cancel errors on already-resolved streams */ })
+    reader.releaseLock()
+  },
+)
+
 const collectChatStream = async function* (
   response: Response,
 ): AsyncGenerator<ProviderStreamEvent, CapturedStreamResult, undefined> {
@@ -197,6 +208,9 @@ const collectChatStream = async function* (
   let outputText = ''
   let usage: InvocationUsage = {}
   let yieldedDelta = false
+
+  // Register reader with finalization registry as a safety net for abandoned streams
+  streamFinalizationRegistry.register(reader, reader)
 
   try {
     while (true) {
@@ -250,6 +264,10 @@ const collectChatStream = async function* (
       }
     }
   } finally {
+    streamFinalizationRegistry.unregister(reader)
+    // Cancel the reader to release the underlying socket back to the pool.
+    // This is safe to call even if the stream is already done.
+    await reader.cancel().catch(() => { /* ignore cancel errors */ })
     reader.releaseLock()
   }
 

--- a/packages/runtime/src/inference/connectors.ts
+++ b/packages/runtime/src/inference/connectors.ts
@@ -186,8 +186,8 @@ const providerError = (input: {
 // before completion, FinalizationRegistry ensures the reader is cancelled and
 // released back to the connection pool, preventing socket leaks.
 // See: openclaw/openclaw#67461
-const streamFinalizationRegistry = new FinalizationRegistry<ReadableStreamDefaultReader>(
-  (reader) => {
+const streamFinalizationRegistry = new FinalizationRegistry<{ reader: ReadableStreamDefaultReader }>(
+  ({ reader }) => {
     reader.cancel().catch(() => { /* ignore cancel errors on already-resolved streams */ })
     reader.releaseLock()
   },
@@ -210,7 +210,7 @@ const collectChatStream = async function* (
   let yieldedDelta = false
 
   // Register reader with finalization registry as a safety net for abandoned streams
-  streamFinalizationRegistry.register(reader, reader)
+  streamFinalizationRegistry.register(reader, { reader })
 
   try {
     while (true) {

--- a/src/llm/streaming.ts
+++ b/src/llm/streaming.ts
@@ -12,6 +12,17 @@ export type LlmStreamOptions = {
   temperature?: number
 }
 
+// Safety net: if a streaming response is abandoned and the generator is GC'd
+// before completion, FinalizationRegistry ensures the reader is cancelled and
+// released back to the connection pool, preventing socket leaks.
+// See: openclaw/openclaw#67461
+const streamFinalizationRegistry = new FinalizationRegistry<ReadableStreamDefaultReader>(
+  (reader) => {
+    reader.cancel().catch(() => { /* ignore cancel errors on already-resolved streams */ })
+    reader.releaseLock()
+  },
+)
+
 /**
  * Yields text deltas from the model. Throws on API error after zero or more deltas.
  */
@@ -63,6 +74,9 @@ async function* openaiStream(
   const decoder = new TextDecoder()
   let buffer = ''
 
+  // Register reader with finalization registry as a safety net for abandoned streams
+  streamFinalizationRegistry.register(reader, reader)
+
   try {
     while (true) {
       const { done, value } = await reader.read()
@@ -88,6 +102,10 @@ async function* openaiStream(
       }
     }
   } finally {
+    streamFinalizationRegistry.unregister(reader)
+    // Cancel the reader to release the underlying socket back to the pool.
+    // This is safe to call even if the stream is already done.
+    await reader.cancel().catch(() => { /* ignore cancel errors */ })
     reader.releaseLock()
   }
 }
@@ -127,6 +145,9 @@ async function* minimaxStream(
   const decoder = new TextDecoder()
   let buffer = ''
 
+  // Register reader with finalization registry as a safety net for abandoned streams
+  streamFinalizationRegistry.register(reader, reader)
+
   try {
     while (true) {
       const { done, value } = await reader.read()
@@ -152,6 +173,10 @@ async function* minimaxStream(
       }
     }
   } finally {
+    streamFinalizationRegistry.unregister(reader)
+    // Cancel the reader to release the underlying socket back to the pool.
+    // This is safe to call even if the stream is already done.
+    await reader.cancel().catch(() => { /* ignore cancel errors */ })
     reader.releaseLock()
   }
 }


### PR DESCRIPTION
## Summary

When streaming HTTP responses are abandoned by consumers (generator abandoned before completion), undici sockets could leak because `reader.cancel()` and `reader.releaseLock()` were only called on natural stream end or explicit generator return - not on stream abandonment.

This PR adds a `FinalizationRegistry` safety net that calls `reader.cancel()` followed by `reader.releaseLock()` when the stream reader is garbage collected before the generator completes.

## Changes

- `packages/runtime/src/inference/connectors.ts`: Added `FinalizationRegistry` to `collectChatStream` function
- `src/llm/streaming.ts`: Added `FinalizationRegistry` to both `openaiStream` and `minimaxStream` functions

## How it works

1. When a streaming response reader is created, it's registered with a module-level `FinalizationRegistry`
2. The registry holds a weak reference to the reader
3. If the generator is abandoned and the reader is GC'd before natural completion:
   - The registry callback fires
   - `reader.cancel()` is called to release the underlying socket back to the pool
   - `reader.releaseLock()` releases the reader lock
4. In the normal completion path (`finally` block), we:
   - Unregister from the registry (avoid double cleanup)
   - Call `reader.cancel()` (safe to call even if stream is done)
   - Call `reader.releaseLock()`

## Fixes

- Fixes UnlikeOtherAI/Nessie#66
- Source: openclaw/openclaw#67461
