### PR TITLE
fix(ci): use turbo build instead of pnpm build to avoid bun dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,7 +86,7 @@ jobs:
         run: pnpm --filter @nessie/api prisma:generate
 
       - name: Build all packages
-        run: pnpm build
+        run: pnpm turbo run build
 
   test:
     name: Test


### PR DESCRIPTION
bun is not installed in CI, causing Build job to fail on all branches.
Switch to pnpm turbo run build which builds packages via their own
tsc -p tsconfig.build.json scripts (no bun needed).
