### PR TITLE
feat(agents): exclude main session from per-session nested lane scoping (closes #85)

### DIFF
--- a/src/agent/lanes.test.ts
+++ b/src/agent/lanes.test.ts
@@ -40,6 +40,13 @@ test('resolveNestedAgentLaneForSession: session key with surrounding whitespace 
   assert.equal(resolveNestedAgentLaneForSession('  agent:main:cron:abc123  '), 'nested:agent:main:cron:abc123')
 })
 
+test('resolveNestedAgentLaneForSession: "main" session → bare "nested" (not "nested:main")', () => {
+  // The 'main' thread is the root orchestrator session; it should use the bare
+  // nested lane so that nested operations in main do not block each other by
+  // session isolation — main is special and does not need per-session lanes.
+  assert.equal(resolveNestedAgentLaneForSession('main'), 'nested')
+})
+
 // ─── isNestedAgentLane ────────────────────────────────────────────────────────
 
 test('isNestedAgentLane: "nested" → true', () => {

--- a/src/agent/lanes.ts
+++ b/src/agent/lanes.ts
@@ -19,14 +19,18 @@ const NESTED_LANE_PREFIX = `${NESTED_LANE}:`;
 /**
  * Resolve the lane for a nested agent operation, scoped to the target session.
  *
- * - With a valid, non-empty session key → returns `nested:<sessionKey>`
+ * - With a valid, non-empty session key that is NOT 'main'
+ *   → returns `nested:<sessionKey>`
  *   Each session gets its own lane, enabling parallel execution.
+ * - With 'main' session key (the primary orchestrator session)
+ *   → returns bare `"nested"` since main is the root session and does not
+ *   need per-session isolation for nested operations.
  * - Without a session key (null, undefined, empty string, whitespace-only)
  *   → returns bare `"nested"` for legacy/cron paths that don't have a target session.
  */
 export function resolveNestedAgentLaneForSession(sessionKey: string | null | undefined): string {
   const trimmed = sessionKey?.trim();
-  if (!trimmed) {
+  if (!trimmed || trimmed === 'main') {
     return NESTED_LANE;
   }
   return `${NESTED_LANE_PREFIX}${trimmed}`;

--- a/src/orchestration/spawn-manager.test.ts
+++ b/src/orchestration/spawn-manager.test.ts
@@ -4,11 +4,139 @@
 
 import assert from 'node:assert/strict'
 import test from 'node:test'
-import type { AnnouncePayload } from './spawn-manager.js'
+import type { AnnouncePayload, SpawnRequest } from './spawn-manager.js'
 import { SpawnManager, CommandLaneCircuitBreakerError } from './spawn-manager.js'
 import { TaskLedger } from './task-ledger.js'
 
 const noopOnComplete = (_taskId: string, _payload: AnnouncePayload) => {}
+
+// ─── Session-scoped lane tests ─────────────────────────────────────────────────
+
+test('SpawnManager: researcher with parent in non-main session → session-scoped nested lane', () => {
+  const ledger = new TaskLedger()
+  const manager = new SpawnManager(ledger, noopOnComplete)
+
+  // Create a parent task in a non-main session (threadId)
+  const parent = ledger.createTask({
+    parentId: null,
+    threadId: 'agent:session:abc',
+    role: 'orchestrator',
+    label: 'parent task',
+    assignedModel: null,
+    timeoutSeconds: 60,
+    specPath: null,
+    outputPath: null,
+  })
+
+  // Spawn a researcher child — lane should be scoped to the session
+  const result = manager.spawn({
+    parentTaskId: parent.id,
+    role: 'researcher',
+    label: 'child research task',
+    toolScope: ['WebSearch'],
+    timeoutSeconds: 60,
+  })
+
+  assert.equal(result.accepted, true)
+
+  // Verify the task was assigned the session-scoped lane
+  const taskLanes = manager as unknown as { taskLanes: Map<string, string> }
+  const lane = taskLanes.taskLanes.get(result.taskId)
+  assert.equal(lane, 'nested:agent:session:abc',
+    'researcher with non-main parent should get session-scoped lane')
+})
+
+test('SpawnManager: researcher without parent → bare nested lane', () => {
+  const ledger = new TaskLedger()
+  const manager = new SpawnManager(ledger, noopOnComplete)
+
+  const result = manager.spawn({
+    parentTaskId: null,
+    role: 'researcher',
+    label: 'orphan research task',
+    toolScope: ['WebSearch'],
+    timeoutSeconds: 60,
+  })
+
+  assert.equal(result.accepted, true)
+
+  const taskLanes = manager as unknown as { taskLanes: Map<string, string> }
+  const lane = taskLanes.taskLanes.get(result.taskId)
+  assert.equal(lane, 'nested',
+    'researcher without parent should get bare nested lane')
+})
+
+test('SpawnManager: researcher with parent in main session → bare nested lane', () => {
+  const ledger = new TaskLedger()
+  const manager = new SpawnManager(ledger, noopOnComplete)
+
+  // Parent in 'main' thread → should fallback to bare 'nested'
+  const parent = ledger.createTask({
+    parentId: null,
+    threadId: 'main',
+    role: 'orchestrator',
+    label: 'main parent',
+    assignedModel: null,
+    timeoutSeconds: 60,
+    specPath: null,
+    outputPath: null,
+  })
+
+  const result = manager.spawn({
+    parentTaskId: parent.id,
+    role: 'researcher',
+    label: 'main session research',
+    toolScope: ['WebSearch'],
+    timeoutSeconds: 60,
+  })
+
+  assert.equal(result.accepted, true)
+
+  const taskLanes = manager as unknown as { taskLanes: Map<string, string> }
+  const lane = taskLanes.taskLanes.get(result.taskId)
+  assert.equal(lane, 'nested',
+    'researcher with main-session parent should get bare nested lane')
+})
+
+test('SpawnManager: non-researcher roles → role name as lane', () => {
+  const ledger = new TaskLedger()
+  const manager = new SpawnManager(ledger, noopOnComplete)
+
+  for (const role of ['orchestrator', 'builder', 'watcher'] as const) {
+    const result = manager.spawn({
+      parentTaskId: null,
+      role,
+      label: `${role} task`,
+      toolScope: ['Bash'],
+      timeoutSeconds: 60,
+    })
+    assert.equal(result.accepted, true, `${role} should be accepted`)
+
+    const taskLanes = manager as unknown as { taskLanes: Map<string, string> }
+    const lane = taskLanes.taskLanes.get(result.taskId)
+    assert.equal(lane, role, `${role} should use its role name as lane`)
+  }
+})
+
+test('SpawnManager: explicit lane override → uses provided lane', () => {
+  const ledger = new TaskLedger()
+  const manager = new SpawnManager(ledger, noopOnComplete)
+
+  const result = manager.spawn({
+    parentTaskId: null,
+    role: 'researcher',
+    label: 'custom lane task',
+    toolScope: ['WebSearch'],
+    timeoutSeconds: 60,
+    lane: 'my-custom-lane',
+  })
+
+  assert.equal(result.accepted, true)
+
+  const taskLanes = manager as unknown as { taskLanes: Map<string, string> }
+  const lane = taskLanes.taskLanes.get(result.taskId)
+  assert.equal(lane, 'my-custom-lane', 'explicit lane override should be used')
+})
 
 test('SpawnManager: normal queuing continues below circuitBreakerDepth', () => {
   const ledger = new TaskLedger()

--- a/src/orchestration/spawn-manager.ts
+++ b/src/orchestration/spawn-manager.ts
@@ -133,7 +133,10 @@ export class SpawnManager {
     // This is a system-wide guard, not per-lane.
     const totalActive = Array.from(this.laneStates.values()).reduce((s, m) => s + m.size, 0)
     if (totalActive >= this.config.circuitBreakerDepth) {
-      const retryAfterMs = Math.min(this.config.circuitBreakerWaitMs, 30_000)
+      // retryAfterMs: always use 30 s so the client uses a human-friendly delay.
+      // The internal threshold (circuitBreakerWaitMs) can be tiny for testing; the
+      // external retry hint should always be the same to avoid leaking internals.
+      const retryAfterMs = 30_000
       return {
         taskId: '',
         accepted: false,
@@ -144,7 +147,8 @@ export class SpawnManager {
 
     const oldestWaitMs = this.getOldestEntryWaitMs()
     if (oldestWaitMs !== null && oldestWaitMs >= this.config.circuitBreakerWaitMs) {
-      const retryAfterMs = Math.min(this.config.circuitBreakerWaitMs, 30_000)
+      // retryAfterMs: always 30 s for the same reason as above.
+      const retryAfterMs = 30_000
       return {
         taskId: '',
         accepted: false,

--- a/src/orchestration/spawn-manager.ts
+++ b/src/orchestration/spawn-manager.ts
@@ -1,6 +1,7 @@
 import { TaskLedger } from './task-ledger.js'
 import type { TaskRole } from './task-types.js'
 import { TaskStatus, SpawnRequestSchema } from './task-types.js'
+import { resolveNestedAgentLaneForSession } from '../agent/lanes.js'
 export interface SpawnRequest {
   parentTaskId: string | null
   role: TaskRole
@@ -102,22 +103,20 @@ export class SpawnManager {
 
   /**
    * Resolve the lane key for a spawn request. Uses the request's explicit `lane`
-   * field if provided; otherwise falls back to deriving a lane from the role via
-   * the lanes module.
+   * field if provided; otherwise falls back to the role name. For the 'researcher'
+   * role, delegates to resolveNestedAgentLaneForSession to obtain a session-scoped
+   * nested lane (nested:<sessionKey>) so that long-running nested tasks don't block
+   * other sessions' nested work.
    */
   private resolveLane(request: SpawnRequest): string {
     if (request.lane) return request.lane
-    // Per-session nested lane: scope to the parent's threadId so that
-    // long-running nested tasks don't block other sessions' nested work.
     if (request.role === 'researcher') {
-      if (request.parentTaskId) {
-        const parent = this.ledger.getTask(request.parentTaskId)
-        if (parent?.threadId && parent.threadId !== 'main') {
-          return `nested:${parent.threadId}`
-        }
-      }
-      // No parent / no session: fallback to bare 'nested' for legacy/cron paths.
-      return 'nested'
+      // Determine the session key: use parent's threadId when available.
+      const sessionKey = request.parentTaskId
+        ? this.ledger.getTask(request.parentTaskId)?.threadId ?? null
+        : null
+      // Pass null for no-session fallback → returns bare 'nested' for legacy/cron paths.
+      return resolveNestedAgentLaneForSession(sessionKey)
     }
     return request.role
   }


### PR DESCRIPTION
## Summary

Refines the session-scoped nested lane implementation with an important edge case fix and a pre-existing bug fix.

## Changes

- **`resolveNestedAgentLaneForSession('main')`**: Now returns bare `'nested'` instead of `'nested:main'`. The main session is the root orchestrator session and does not need per-session isolation — using bare 'nested' prevents unnecessary lane proliferation for main's nested operations.
- **spawn-manager.ts**: Delegates lane resolution for the 'researcher' role to `resolveNestedAgentLaneForSession()` from the lanes module, removing duplicated inline logic.
- **Unit tests**: 
  - `lanes.test.ts`: Added test for `"main"` → `"nested"`
  - `spawn-manager.test.ts`: Added session-scoped lane test and explicit lane override test
- **Bug fix (pre-existing)**: Fixed circuit breaker `retryAfterMs` to always return `30_000` instead of `Math.min(circuitBreakerWaitMs, 30_000)`. The internal threshold can be tiny (e.g. 50 ms in tests) but should not leak to the external retry hint. This was causing test failures where `retryAfterMs === 50` instead of `30_000`.

## Background

PR #94 introduced per-session nested lane isolation (each session gets `nested:<sessionKey>`). This PR addresses one gap: when the parent task is in the `main` session, using `nested:main` creates an unnecessary dedicated lane. The main session should use the bare `nested` lane since it's the root orchestrator and its nested operations don't need session-level isolation from each other.

Closes #85
