### PR TITLE
feat(agent): add formatAgentError() with cause-chain deduplication (#121)

### DIFF
--- a/src/agent/Orchestrator.ts
+++ b/src/agent/Orchestrator.ts
@@ -32,6 +32,7 @@ import { runBeforeToolCall, runAfterToolCall } from '../plugins/hook-registry.js
 import type { BeforeToolCallContext } from '../plugins/hook-types.js'
 import type { OpenClawEvent, OpenClawAgentConfig } from '../openclaw/index.js'
 import { dispatchWithFailover } from './dispatch.js'
+import { formatAgentError } from './errors.js'
 
 export class Orchestrator {
   private state: OrchestratorState
@@ -204,7 +205,7 @@ export class Orchestrator {
             yield delta
           }
         } catch (err) {
-          const msg = err instanceof Error ? err.message : String(err)
+          const msg = formatAgentError(err)
           this.callbacks.onBroadcast?.({ type: 'error', message: msg })
           yield `LLM error: ${msg}`
           return
@@ -248,7 +249,7 @@ export class Orchestrator {
         yield delta
       }
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = formatAgentError(err)
       this.callbacks.onBroadcast?.({ type: 'error', message: msg })
       yield `LLM error: ${msg}`
       return
@@ -473,7 +474,7 @@ export class Orchestrator {
     try {
       rawResult = await this.spawnSubAgent(subAgent)
     } catch (err) {
-      const errMsg = err instanceof Error ? err.message : String(err)
+      const errMsg = formatAgentError(err)
       rawResult = errMsg
       success = false
     }
@@ -627,7 +628,7 @@ export class Orchestrator {
       )
       return data
     } catch (err) {
-      const msg = err instanceof Error ? err.message : String(err)
+      const msg = formatAgentError(err)
       this.callbacks.onBroadcast?.({ type: 'tool.done', name: toolName, output: { error: msg } })
       // Fire after_tool_call with error (fire-and-forget)
       void runAfterToolCall(
@@ -666,7 +667,7 @@ export class Orchestrator {
       })
       this.callbacks.onBroadcast?.({ type: 'agent.wake', agentId, reason })
     } catch (error) {
-      const errMsg = error instanceof Error ? error.message : String(error)
+      const errMsg = formatAgentError(error)
       this.pushMessage({ role: 'system', threadId: 'main', content: `${agent.name} failed: ${errMsg}` })
     }
   }

--- a/src/agent/dispatch.ts
+++ b/src/agent/dispatch.ts
@@ -7,7 +7,7 @@
  */
 
 import type { LlmClient } from '../llm/client.js'
-import { AgentError, AgentErrorCode } from './errors.js'
+import { AgentError, AgentErrorCode, formatAgentError } from './errors.js'
 
 export interface DispatchOptions {
   /** Fallback backend URLs to try in order. Empty = single-backend mode. */
@@ -102,7 +102,7 @@ export async function dispatchWithFailover(
       throw primaryErr
     }
     // Primary failed with a retryable error — try backends
-    console.warn(`[dispatch] Primary backend failed (${(primaryErr as Error).message}), trying fallback backends...`)
+    console.warn(`[dispatch] Primary backend failed (${formatAgentError(primaryErr)}), trying fallback backends...`)
     errors.push(primaryErr as Error)
   }
 
@@ -122,7 +122,7 @@ export async function dispatchWithFailover(
       if (!isRetryable || i === backends.length - 1) {
         break
       }
-      console.warn(`[dispatch] Backend ${backend} failed (${(err as Error).message}), trying next...`)
+      console.warn(`[dispatch] Backend ${backend} failed (${formatAgentError(err)}), trying next...`)
     }
   }
 

--- a/src/agent/errors.test.ts
+++ b/src/agent/errors.test.ts
@@ -1,0 +1,225 @@
+/**
+ * src/agent/errors.test.ts — Tests for formatAgentError and AgentError types.
+ */
+
+import assert from 'node:assert/strict'
+import test from 'node:test'
+import { AgentError, AgentErrorCode, formatAgentError } from './errors.js'
+
+// ─── formatAgentError: basic cases ──────────────────────────────────────────
+
+test('formatAgentError: formats plain Error message', () => {
+  const err = new Error('something broke')
+  assert.equal(formatAgentError(err), 'something broke')
+})
+
+test('formatAgentError: formats string directly', () => {
+  assert.equal(formatAgentError('plain string error'), 'plain string error')
+})
+
+test('formatAgentError: formats number', () => {
+  assert.equal(formatAgentError(42), '42')
+})
+
+test('formatAgentError: formats boolean', () => {
+  assert.equal(formatAgentError(false), 'false')
+})
+
+test('formatAgentError: formats bigint', () => {
+  assert.equal(formatAgentError(123n), '123')
+})
+
+test('formatAgentError: formats plain object via JSON', () => {
+  assert.equal(formatAgentError({ foo: 'bar' }), '{"foo":"bar"}')
+})
+
+test('formatAgentError: formats null', () => {
+  assert.equal(formatAgentError(null), '')
+})
+
+test('formatAgentError: formats undefined', () => {
+  assert.equal(formatAgentError(undefined), '')
+})
+
+test('formatAgentError: uses Error.name when message is empty', () => {
+  const err = new Error('')
+  err.name = 'CustomError'
+  assert.equal(formatAgentError(err), 'CustomError')
+})
+
+// ─── formatAgentError: .cause chain traversal ───────────────────────────────
+
+test('formatAgentError: traverses .cause chain', () => {
+  const root = new Error('root cause')
+  const wrapped = new Error('wrapped error')
+  ;(wrapped as Error & { cause?: unknown }).cause = root
+  assert.equal(formatAgentError(wrapped), 'wrapped error | root cause')
+})
+
+test('formatAgentError: traverses nested .cause chain (3 levels)', () => {
+  const deep = new Error('deep cause')
+  const mid = new Error('middle error')
+  ;(mid as Error & { cause?: unknown }).cause = deep
+  const top = new Error('top error')
+  ;(top as Error & { cause?: unknown }).cause = mid
+  assert.equal(formatAgentError(top), 'top error | middle error | deep cause')
+})
+
+// ─── formatAgentError: deduplication ────────────────────────────────────────
+
+test('formatAgentError: deduplicates repeated messages in chain', () => {
+  const root = new Error('same message')
+  const wrapped = new Error('same message')
+  ;(wrapped as Error & { cause?: unknown }).cause = root
+  assert.equal(formatAgentError(wrapped), 'same message')
+})
+
+test('formatAgentError: deduplicates partially repeated chain', () => {
+  const root = new Error('shared')
+  const mid = new Error('shared')
+  ;(mid as Error & { cause?: unknown }).cause = root
+  const top = new Error('unique top')
+  ;(top as Error & { cause?: unknown }).cause = mid
+  assert.equal(formatAgentError(top), 'unique top | shared')
+})
+
+// ─── formatAgentError: circular references ──────────────────────────────────
+
+test('formatAgentError: handles circular .cause without infinite loop', () => {
+  const a: Error & { cause?: unknown } = new Error('error A')
+  const b: Error & { cause?: unknown } = new Error('error B')
+  a.cause = b
+  b.cause = a
+  assert.equal(formatAgentError(a), 'error A | error B')
+})
+
+test('formatAgentError: handles self-referential .cause', () => {
+  const err: Error & { cause?: unknown } = new Error('self-referential')
+  err.cause = err
+  assert.equal(formatAgentError(err), 'self-referential')
+})
+
+// ─── formatAgentError: string causes ──────────────────────────────────────────
+
+test('formatAgentError: handles string .cause', () => {
+  const err: Error & { cause?: unknown } = new Error('wrapper')
+  err.cause = 'string cause'
+  assert.equal(formatAgentError(err), 'wrapper | string cause')
+})
+
+test('formatAgentError: deduplicates string .cause equal to message', () => {
+  const err: Error & { cause?: unknown } = new Error('duplicate')
+  err.cause = 'duplicate'
+  assert.equal(formatAgentError(err), 'duplicate')
+})
+
+// ─── formatAgentError: AgentError with Error[] cause ────────────────────────
+
+test('formatAgentError: flattens AgentError.cause array into chain', () => {
+  const cause1 = new Error('first backend failed')
+  const cause2 = new Error('second backend failed')
+  const err = new AgentError('all backends exhausted', {
+    code: AgentErrorCode.ALL_BACKENDS_EXHAUSTED,
+    cause: [cause1, cause2],
+  })
+  assert.equal(formatAgentError(err), 'all backends exhausted | first backend failed | second backend failed')
+})
+
+test('formatAgentError: deduplicates across AgentError.cause array', () => {
+  const cause1 = new Error('timeout')
+  const cause2 = new Error('timeout')
+  const err = new AgentError('all failed', {
+    code: AgentErrorCode.ALL_BACKENDS_EXHAUSTED,
+    cause: [cause1, cause2],
+  })
+  assert.equal(formatAgentError(err), 'all failed | timeout')
+})
+
+test('formatAgentError: handles AgentError with single Error cause', () => {
+  const cause = new Error('underlying problem')
+  const err = new AgentError('agent failed', {
+    code: AgentErrorCode.INFERENCE_FAILED,
+    cause,
+  })
+  assert.equal(formatAgentError(err), 'agent failed | underlying problem')
+})
+
+test('formatAgentError: handles AgentError with empty cause array', () => {
+  const err = new AgentError('agent failed', {
+    code: AgentErrorCode.TOOL_EXECUTION_FAILED,
+    cause: [],
+  })
+  assert.equal(formatAgentError(err), 'agent failed')
+})
+
+test('formatAgentError: handles AgentError with mixed cause array (Error + string)', () => {
+  const cause1 = new Error('error cause')
+  const err = new AgentError('mixed causes', {
+    code: AgentErrorCode.ALL_BACKENDS_EXHAUSTED,
+    // @ts-expect-error — testing runtime resilience with non-Error in cause array
+    cause: [cause1, 'string cause'],
+  })
+  assert.equal(formatAgentError(err), 'mixed causes | error cause | string cause')
+})
+
+test('formatAgentError: deduplicates AgentError.cause with parent message', () => {
+  const cause = new Error('same as parent')
+  const err = new AgentError('same as parent', {
+    code: AgentErrorCode.ALL_BACKENDS_EXHAUSTED,
+    cause: [cause],
+  })
+  assert.equal(formatAgentError(err), 'same as parent')
+})
+
+// ─── formatAgentError: nested AgentError chains ───────────────────────────────
+
+test('formatAgentError: handles nested AgentError with their own causes', () => {
+  const deepCause = new Error('database timeout')
+  const midErr = new AgentError('inference failed', {
+    code: AgentErrorCode.INFERENCE_FAILED,
+    cause: deepCause,
+  })
+  const topErr = new AgentError('all backends exhausted', {
+    code: AgentErrorCode.ALL_BACKENDS_EXHAUSTED,
+    cause: [midErr, new Error('network unreachable')],
+  })
+  assert.equal(
+    formatAgentError(topErr),
+    'all backends exhausted | inference failed | database timeout | network unreachable',
+  )
+})
+
+// ─── formatAgentError: complex scenarios ────────────────────────────────────
+
+test('formatAgentError: handles Error with .cause containing AgentError', () => {
+  const agentErr = new AgentError('tool execution failed', {
+    code: AgentErrorCode.TOOL_EXECUTION_FAILED,
+    cause: new Error('command not found'),
+  })
+  const wrapper = new Error('request failed')
+  ;(wrapper as Error & { cause?: unknown }).cause = agentErr
+  assert.equal(formatAgentError(wrapper), 'request failed | tool execution failed | command not found')
+})
+
+test('formatAgentError: handles deeply nested circular references', () => {
+  const a: Error & { cause?: unknown } = new Error('A')
+  const b: Error & { cause?: unknown } = new Error('B')
+  const c: Error & { cause?: unknown } = new Error('C')
+  a.cause = b
+  b.cause = c
+  c.cause = a // circular back to a
+  assert.equal(formatAgentError(a), 'A | B | C')
+})
+
+// ─── AgentError structure ───────────────────────────────────────────────────
+
+test('AgentError: has code, name, message, and cause', () => {
+  const cause = [new Error('first'), new Error('second')]
+  const err = new AgentError('all failed', { code: AgentErrorCode.ALL_BACKENDS_EXHAUSTED, cause })
+
+  assert.equal(err.name, 'AgentError')
+  assert.equal(err.message, 'all failed')
+  assert.equal(err.code, 'ALL_BACKENDS_EXHAUSTED')
+  assert.equal((err.cause as Error[]).length, 2)
+  assert.equal(err instanceof Error, true)
+})

--- a/src/agent/errors.ts
+++ b/src/agent/errors.ts
@@ -16,7 +16,7 @@ export type AgentErrorCodeType = (typeof AgentErrorCode)[keyof typeof AgentError
  * Carries a machine-readable code for programmatic error handling.
  */
 export class AgentError extends Error {
-  readonly code: AgentErrorCodeType
+  readonly code: AgentErrorCodeType | 'UNKNOWN'
   readonly cause: Error | Error[]
 
   constructor(
@@ -28,4 +28,77 @@ export class AgentError extends Error {
     this.code = (options.code as AgentErrorCodeType) ?? 'UNKNOWN'
     this.cause = options.cause ?? []
   }
+}
+
+/**
+ * Format an error (or any thrown value) into a human-readable string.
+ *
+ * Traverses `.cause` chains, deduplicates repeated messages, handles circular
+ * references, and flattens `AgentError.cause` (Error | Error[]) into a single
+ * deduplicated chain.
+ *
+ * @param err - Any thrown value (Error, string, number, object, etc.)
+ * @returns A formatted, deduplicated error message string
+ */
+export function formatAgentError(err: unknown): string {
+  const messages: string[] = []
+  const seen = new Set<unknown>()
+
+  function collect(current: unknown) {
+    if (current == null || seen.has(current)) {
+      return
+    }
+    seen.add(current)
+
+    if (current instanceof Error) {
+      const msg = current.message || current.name || 'Error'
+      if (msg && !messages.includes(msg)) {
+        messages.push(msg)
+      }
+
+      // Handle AgentError.cause which can be Error | Error[]
+      if (current instanceof AgentError) {
+        const causes = Array.isArray(current.cause) ? current.cause : [current.cause]
+        for (const c of causes) {
+          if (c instanceof Error) {
+            collect(c)
+          } else if (typeof c === 'string' && c && !messages.includes(c)) {
+            messages.push(c)
+          }
+        }
+      } else {
+        // Standard Error.cause
+        const cause = (current as Error & { cause?: unknown }).cause
+        if (cause instanceof Error) {
+          collect(cause)
+        } else if (typeof cause === 'string' && cause && !messages.includes(cause)) {
+          messages.push(cause)
+        }
+      }
+    } else if (typeof current === 'string') {
+      if (current && !messages.includes(current)) {
+        messages.push(current)
+      }
+    } else if (typeof current === 'number' || typeof current === 'boolean' || typeof current === 'bigint') {
+      const s = String(current)
+      if (!messages.includes(s)) {
+        messages.push(s)
+      }
+    } else {
+      try {
+        const s = JSON.stringify(current)
+        if (s && !messages.includes(s)) {
+          messages.push(s)
+        }
+      } catch {
+        const s = Object.prototype.toString.call(current)
+        if (!messages.includes(s)) {
+          messages.push(s)
+        }
+      }
+    }
+  }
+
+  collect(err)
+  return messages.join(' | ')
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import type { ServerEvent } from './events.js'
 import { McpServer, parseJsonRpcRequest } from './mcp/server.js'
 import { createMcpAdapter } from './mcp/adapter.js'
 import { deleteHistory } from './db/database.js'
+import { formatAgentError } from './agent/errors.js'
 import { loadConfig } from '../packages/config/src/index.js'
 import bonjour from 'bonjour'
 // Workflow RPC handlers
@@ -185,7 +186,7 @@ async function main() {
   try {
     llm = createLlmClient()
   } catch (error) {
-    console.warn(`Warning: chat LLM unavailable — ${error instanceof Error ? error.message : String(error)}`)
+    console.warn(`Warning: chat LLM unavailable — ${formatAgentError(error)}`)
   }
 
   // Use validated backends from loadConfig — parsed and URL-validated via ConfigEnvMap.
@@ -386,7 +387,7 @@ async function main() {
           // nothing to yield — broadcast handles SSE delivery
         }
       } catch (error) {
-        emit({ type: 'error', message: error instanceof Error ? error.message : String(error) })
+        emit({ type: 'error', message: formatAgentError(error) })
       } finally {
         sendSSE(res, 'end', {})
         sseStreams.delete(streamId)
@@ -417,7 +418,7 @@ async function main() {
         res.end(JSON.stringify({ reply }))
       } catch (error) {
         res.writeHead(500, { 'Content-Type': 'application/json' })
-        res.end(JSON.stringify({ error: error instanceof Error ? error.message : String(error) }))
+        res.end(JSON.stringify({ error: formatAgentError(error) }))
       }
       return
     }
@@ -669,7 +670,7 @@ async function main() {
       }
       ws.send(JSON.stringify({ type: 'response_done', content: fullResponse }))
     } catch (error) {
-      ws.send(JSON.stringify({ type: 'error', message: error instanceof Error ? error.message : String(error) }))
+      ws.send(JSON.stringify({ type: 'error', message: formatAgentError(error) }))
     }
   }
 

--- a/src/mcp/adapter.ts
+++ b/src/mcp/adapter.ts
@@ -13,6 +13,7 @@ import type { Orchestrator } from '../agent/Orchestrator.js'
 import { allTools, findToolByName } from '../tools/index.js'
 import type { ToolUseContext } from '../tools/types.js'
 import { CreateTaskSchema } from '../orchestration/task-types.js'
+import { formatAgentError } from '../agent/errors.js'
 import type { TaskRole } from '../orchestration/task-types.js'
 import { runBeforeToolCall, runAfterToolCall } from '../plugins/hook-registry.js'
 import type { BeforeToolCallContext } from '../plugins/hook-types.js'
@@ -128,7 +129,7 @@ export function createMcpAdapter(orchestrator: Orchestrator): McpOrchestrator {
         )
         return JSON.stringify(result.data, null, 2)
       } catch (err) {
-        const msg = err instanceof Error ? err.message : String(err)
+        const msg = formatAgentError(err)
         orchestrator.broadcastToolEvent({ type: 'tool.done', name: toolName, output: { error: msg } })
         // Fire after_tool_call with error (fire-and-forget)
         void runAfterToolCall(

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,6 +8,7 @@
  */
 
 import { CreateTaskSchema, SpawnRequestSchema } from '../orchestration/task-types.js'
+import { formatAgentError } from '../agent/errors.js'
 
 // ─── Tool definitions ─────────────────────────────────────────────────────────
 
@@ -491,7 +492,7 @@ export class McpServer {
         id: req.id ?? null,
         error: {
           code: -32603,
-          message: err instanceof Error ? err.message : String(err),
+          message: formatAgentError(err),
         },
       }
     }
@@ -554,7 +555,7 @@ export class McpServer {
           response += delta
         }
       } catch (err) {
-        response = `Error: ${err instanceof Error ? err.message : String(err)}`
+        response = `Error: ${formatAgentError(err)}`
       }
       return {
         jsonrpc: '2.0', id: req.id ?? null,

--- a/src/plugins/hook-registry.ts
+++ b/src/plugins/hook-registry.ts
@@ -5,6 +5,7 @@
  * Adapted from OpenClaw plugin-sdk (https://github.com/openclaw/openclaw/pull/18810)
  */
 
+import { formatAgentError } from '../agent/errors.js'
 import type {
   BeforeToolCallEvent,
   BeforeToolCallResult,
@@ -87,7 +88,7 @@ export async function runBeforeToolCall(
       // Fail-resilient: if hook throws, continue with tool execution
       console.warn(
         '[hook-registry] before_tool_call hook threw:',
-        err instanceof Error ? err.message : String(err),
+        formatAgentError(err),
       )
     }
   }
@@ -108,11 +109,11 @@ export function runAfterToolCall(event: AfterToolCallEvent, context: AfterToolCa
       const result = handler(event, context)
       if (result && typeof result === 'object' && 'then' in result) {
         ;(result as Promise<unknown>).catch((err) => {
-          console.error('[hook-registry] after_tool_call hook error:', err)
+          console.error('[hook-registry] after_tool_call hook error:', formatAgentError(err))
         })
       }
     } catch (err) {
-      console.error('[hook-registry] after_tool_call hook error:', err)
+      console.error('[hook-registry] after_tool_call hook error:', formatAgentError(err))
     }
   }
 }


### PR DESCRIPTION
Port OpenClaw's `formatErrorMessage` error-cause deduplication utility into Nessie as `formatAgentError()`.

## Changes

### New: `src/agent/errors.ts`
- Added `formatAgentError(err: unknown): string` function
- Traverses `.cause` chains (standard `Error.cause` and `AgentError.cause`)
- Deduplicates repeated messages across the chain
- Handles circular references without infinite loops
- Handles string causes
- Flattens `AgentError.cause` (`Error | Error[]`) into deduplicated chain

### New: `src/agent/errors.test.ts`
- 27 comprehensive test cases covering:
  - Basic error formatting
  - `.cause` chain traversal (2 and 3 levels)
  - Deduplication of repeated messages
  - Circular `.cause` references
  - Self-referential `.cause`
  - String causes
  - `AgentError` with `Error[]` cause flattening
  - `AgentError` with single `Error` cause
  - Empty cause arrays
  - Mixed cause arrays (Error + string)
  - Nested `AgentError` chains
  - Deeply nested circular references

### Updated call sites
- `src/index.ts` — WS/HTTP error handlers (4 locations)
- `src/agent/dispatch.ts` — console.warn for backend failures (2 locations)
- `src/agent/Orchestrator.ts` — spawnSubAgent error broadcast, handleAnnounce, postWeatherUpdate, streamResponse error broadcast, tool error broadcast (5 locations)
- `src/mcp/server.ts` — JSON-RPC error responses (2 locations)
- `src/mcp/adapter.ts` — tool error broadcasts (1 location)
- `src/plugins/hook-registry.ts` — hook error logging (2 locations)

### Reference
- OpenClaw commit: `447a3643c69b9ed8cd6a80dd99ecc5299ea4e02a`
- OpenClaw PR: #84556
- Fixes: #121