### PR TITLE
fix(mcp-client): bound tools/list discovery

### DIFF
--- a/packages/mcp-client/src/client.ts
+++ b/packages/mcp-client/src/client.ts
@@ -24,6 +24,7 @@ const CLIENT_NAME = '@nessie/mcp-client'
 const CLIENT_VERSION = '0.0.0'
 
 const DEFAULT_CALL_TIMEOUT_MS = 30_000
+const DEFAULT_LIST_TOOLS_TIMEOUT_MS = 30_000
 
 export type ConnectionListener = {
   onState: (state: McpConnectionState) => void
@@ -85,14 +86,27 @@ export class McpConnection {
     this.setState('closed')
   }
 
-  async listTools(refresh = false): Promise<McpToolDescriptor[]> {
+  async listTools(
+    refresh = false,
+    opts: { timeoutMs?: number; abort?: AbortSignal } = {},
+  ): Promise<McpToolDescriptor[]> {
     const client = this.requireClient()
+    const timeoutMs = opts.timeoutMs ?? DEFAULT_LIST_TOOLS_TIMEOUT_MS
+    const abort = opts.abort
+
+    if (abort?.aborted) throw classifyError(abort.reason ?? new Error('aborted'))
+
     if (!refresh) {
       const cached = this.cache.get(this.id)
       if (cached) return cached
     }
     try {
-      const raw = await client.listTools()
+      const raw = await this.withTimeoutAndAbort(
+        (signal) => client.listTools(undefined, { signal, timeout: timeoutMs }),
+        timeoutMs,
+        abort,
+        'tools/list',
+      )
       const tools = normaliseTools(raw)
       this.cache.set(this.id, tools)
       return tools
@@ -129,6 +143,7 @@ export class McpConnection {
         (signal) => client.callTool(params, undefined, { signal, timeout: timeoutMs }),
         timeoutMs,
         abort,
+        'tool call',
       )
       return normaliseCallResult(result)
     } catch (err) {
@@ -260,10 +275,11 @@ export class McpConnection {
     body: (signal: AbortSignal) => Promise<T>,
     timeoutMs: number,
     abort?: AbortSignal,
+    operation = 'mcp operation',
   ): Promise<T> {
     const controller = new AbortController()
     const timer = setTimeout(
-      () => controller.abort(new McpTimeoutError(`tool call timed out after ${timeoutMs}ms`, timeoutMs)),
+      () => controller.abort(new McpTimeoutError(`${operation} timed out after ${timeoutMs}ms`, timeoutMs)),
       timeoutMs,
     )
     const onUserAbort = (): void => {

--- a/packages/mcp-client/src/manager.ts
+++ b/packages/mcp-client/src/manager.ts
@@ -64,13 +64,19 @@ export class McpClientManager {
     await conn.close()
   }
 
-  async listTools(id: McpConnectionId): Promise<McpToolDescriptor[]> {
-    return this.requireConnection(id).listTools(false)
+  async listTools(
+    id: McpConnectionId,
+    opts?: { timeoutMs?: number; abort?: AbortSignal },
+  ): Promise<McpToolDescriptor[]> {
+    return this.requireConnection(id).listTools(false, opts)
   }
 
   /** Force a fresh `tools/list` round-trip, bypassing the discovery cache. */
-  async refresh(id: McpConnectionId): Promise<McpToolDescriptor[]> {
-    return this.requireConnection(id).listTools(true)
+  async refresh(
+    id: McpConnectionId,
+    opts?: { timeoutMs?: number; abort?: AbortSignal },
+  ): Promise<McpToolDescriptor[]> {
+    return this.requireConnection(id).listTools(true, opts)
   }
 
   async callTool(

--- a/packages/mcp-client/test/manager.test.ts
+++ b/packages/mcp-client/test/manager.test.ts
@@ -10,6 +10,7 @@ import {
   type McpConnectionId,
   type McpManagerEvent,
 } from '../src/index.js'
+import { McpConnection } from '../src/client.js'
 import { startHttpFake } from './fake-server.js'
 
 test('Backoff returns null once budget exhausted', () => {
@@ -117,6 +118,36 @@ test('callTool timeoutMs raises a typed TIMEOUT error', async () => {
   } finally {
     await fake.close()
   }
+})
+
+test('listTools timeoutMs raises a typed TIMEOUT error', async () => {
+  const conn = new McpConnection(
+    'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee' as McpConnectionId,
+    { transport: 'http', url: 'http://127.0.0.1/mcp' },
+    {
+      onState: () => {},
+      onError: () => {},
+      onNotification: () => {},
+    },
+  )
+  ;(conn as unknown as {
+    client: {
+      listTools: (
+        params?: unknown,
+        opts?: { signal?: AbortSignal },
+      ) => Promise<Record<string, unknown>>
+    }
+  }).client = {
+    listTools: (_params, opts) =>
+      new Promise((_resolve, reject) => {
+        opts?.signal?.addEventListener('abort', () => reject(opts.signal?.reason), { once: true })
+      }),
+  }
+
+  await assert.rejects(
+    () => conn.listTools(false, { timeoutMs: 10 }),
+    (err: unknown) => err instanceof McpTimeoutError && err.kind === 'TIMEOUT',
+  )
 })
 
 test('operations on unknown connection ids raise NOT_CONNECTED', async () => {


### PR DESCRIPTION
## Summary

I am an AI agent helping with #126.

This bounds MCP catalog discovery the same way tool calls are already bounded:

- adds a default 30s timeout for `McpConnection.listTools()`
- threads optional `{ timeoutMs, abort }` through `McpClientManager.listTools()` and `refresh()`
- passes `{ signal, timeout }` into the SDK `client.listTools()` request
- classifies timeout aborts as `McpTimeoutError`
- keeps cache hits fast and does not spend a timeout budget when the cached tool list is returned
- adds focused regression coverage for a stalled `tools/list`

Closes #126.

## Verification

- `NO_PROXY=127.0.0.1,localhost node --test --import tsx test/manager.test.ts` (11 tests passed)
- `corepack pnpm --filter @nessie/mcp-client typecheck`
- `corepack pnpm --filter @nessie/mcp-client lint`

Note: `corepack pnpm --filter @nessie/mcp-client test -- test/manager.test.ts` invokes the package glob and ran the full mcp-client suite in this environment. The HTTP/SSE fake-server tests failed here with `fetch failed: other side closed` until I bypassed the local proxy for loopback via `NO_PROXY=127.0.0.1,localhost`; the targeted manager test then passed.