### PR TITLE
fix(tools): sanitize numeric inputs for BashTool, FileReadTool, and MCP list_messages

### DIFF
--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -8,6 +8,7 @@
  */
 
 import { CreateTaskSchema, SpawnRequestSchema } from '../orchestration/task-types.js'
+import { normalizePositiveLimit } from '../tools/limits.js'
 
 // ─── Tool definitions ─────────────────────────────────────────────────────────
 
@@ -629,9 +630,10 @@ export class McpServer {
     }
 
     if (name === 'list_messages') {
+      const limit = normalizePositiveLimit(args.limit as number | undefined, 50)
       const result = this.orchestrator.listMessages({
         threadId: args.threadId as string | undefined,
-        limit: typeof args.limit === 'number' ? Math.min(Math.floor(args.limit), 200) : 50,
+        limit: Math.min(limit, 200),
         offset: typeof args.offset === 'number' ? Math.floor(args.offset) : 0,
         direction: args.direction as 'older' | 'newer' | undefined,
       })

--- a/src/tools/BashTool.ts
+++ b/src/tools/BashTool.ts
@@ -3,6 +3,7 @@ import { buildTool } from './Tool.js'
 import type { Tool } from './Tool.js'
 import { exec } from 'child_process'
 import { promisify } from 'util'
+import { normalizePositiveLimit } from './limits.js'
 
 const execAsync = promisify(exec)
 
@@ -21,7 +22,7 @@ export function createBashTool(): Tool<BashToolInput, { stdout: string; stderr: 
     inputSchema: BashToolSchema,
 
     async call(args, _context) {
-      const timeout = args.timeout ?? 30000
+      const timeout = normalizePositiveLimit(args.timeout, 30000)
       try {
         const { stdout, stderr } = await execAsync(args.command, { timeout })
         return { data: { stdout, stderr, exitCode: 0 } }

--- a/src/tools/FileReadTool.ts
+++ b/src/tools/FileReadTool.ts
@@ -2,6 +2,7 @@ import { z } from 'zod'
 import { buildTool } from './Tool.js'
 import type { Tool } from './Tool.js'
 import { readFile } from 'fs/promises'
+import { normalizePositiveLimit } from './limits.js'
 
 const FileReadSchema = z.object({
   file_path: z.string(),
@@ -19,9 +20,9 @@ export function createFileReadTool(): Tool<FileReadInput, { content: string; fil
 
     async call(args, _ctx) {
       const content = await readFile(args.file_path, 'utf-8')
-      const offset = args.offset ?? 0
-      const limit = args.limit
-      const sliced = limit ? content.slice(offset, offset + limit) : content.slice(offset)
+      const offset = normalizePositiveLimit(args.offset, 0)
+      const limit = args.limit === undefined ? undefined : normalizePositiveLimit(args.limit, 50_000)
+      const sliced = limit !== undefined ? content.slice(offset, offset + limit) : content.slice(offset)
       return { data: { content: sliced, file_path: args.file_path } }
     },
 

--- a/src/tools/limits.test.ts
+++ b/src/tools/limits.test.ts
@@ -1,0 +1,49 @@
+import { normalizePositiveLimit } from './limits.js'
+
+describe('normalizePositiveLimit', () => {
+  it('returns the value when it is a positive finite number', () => {
+    expect(normalizePositiveLimit(10, 5)).toBe(10)
+    expect(normalizePositiveLimit(1, 5)).toBe(1)
+    expect(normalizePositiveLimit(100, 5)).toBe(100)
+  })
+
+  it('floors non-integer values', () => {
+    expect(normalizePositiveLimit(10.9, 5)).toBe(10)
+    expect(normalizePositiveLimit(1.1, 5)).toBe(1)
+  })
+
+  it('returns fallback for undefined', () => {
+    expect(normalizePositiveLimit(undefined, 50)).toBe(50)
+    expect(normalizePositiveLimit(undefined, 0)).toBe(0)
+  })
+
+  it('returns fallback for NaN', () => {
+    expect(normalizePositiveLimit(NaN, 30)).toBe(30)
+  })
+
+  it('returns fallback for Infinity', () => {
+    expect(normalizePositiveLimit(Infinity, 30)).toBe(30)
+    expect(normalizePositiveLimit(-Infinity, 30)).toBe(30)
+  })
+
+  it('returns fallback for zero', () => {
+    expect(normalizePositiveLimit(0, 10)).toBe(10)
+  })
+
+  it('returns fallback for negative numbers', () => {
+    expect(normalizePositiveLimit(-1, 10)).toBe(10)
+    expect(normalizePositiveLimit(-100, 10)).toBe(10)
+  })
+
+  it('returns at least 1 when value is positive (Math.max(1, ...))', () => {
+    // 0.1 is >0 and isFinite, so it passes the first check.
+    // Math.max(1, Math.floor(0.1)) = Math.max(1, 0) = 1
+    expect(normalizePositiveLimit(0.1, 5)).toBe(1)
+    // 1.5 passes the >0 check, floors to 1
+    expect(normalizePositiveLimit(1.5, 5)).toBe(1)
+    // A value >1 that floors to 1 (edge case)
+    expect(normalizePositiveLimit(1.01, 5)).toBe(1)
+    // Normal case
+    expect(normalizePositiveLimit(2.9, 5)).toBe(2)
+  })
+})

--- a/src/tools/limits.ts
+++ b/src/tools/limits.ts
@@ -1,0 +1,6 @@
+export function normalizePositiveLimit(value: number | undefined, fallback: number): number {
+  if (value === undefined || !Number.isFinite(value) || value <= 0) {
+    return fallback
+  }
+  return Math.max(1, Math.floor(value))
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: 'node',
+  },
+})


### PR DESCRIPTION
Fixes #156

Adds `normalizePositiveLimit()` to reject NaN, Infinity, negative, and zero values from tool numeric arguments.

**Changes:**
- `src/tools/limits.ts` — new utility with comprehensive edge-case handling
- `src/tools/limits.test.ts` — 8 unit tests covering all edge cases
- `src/tools/BashTool.ts` — sanitize timeout (fallback 30000)
- `src/tools/FileReadTool.ts` — sanitize offset (fallback 0) and limit (fallback 50000)
- `src/mcp/server.ts` — sanitize list_messages limit (fallback 50, then capped at 200)
- `vitest.config.ts` — added for test runner configuration

**Verification:**
- ✅ All 8 unit tests pass
- ✅ ESLint clean on all changed files
- ✅ No unrelated changes