### PR TITLE
feat(pa): Personal Assistant is a privileged org-wide owner-delegate

### DIFF
--- a/api/src/services/messages.ts
+++ b/api/src/services/messages.ts
@@ -173,7 +173,11 @@ export const listThreadMessages = async (
   const limit = Math.min(options.limit ?? DEFAULT_MESSAGE_PAGE_SIZE, MAX_MESSAGE_PAGE_SIZE)
 
   const where: Prisma.MessageWhereInput = { threadId }
-  const andClauses: Prisma.MessageWhereInput[] = []
+  const andClauses: Prisma.MessageWhereInput[] = [
+    // Internal/hidden messages (e.g. the personal assistant's scheduled kickoff
+    // prompt) drive a run but are never rendered in the thread feed.
+    { NOT: { metadata: { path: ['hidden'], equals: true } } },
+  ]
 
   if (options.before) {
     const parsed = parseMessageCursor(options.before)

--- a/api/src/services/messages.ts
+++ b/api/src/services/messages.ts
@@ -172,12 +172,10 @@ export const listThreadMessages = async (
 ): Promise<ListThreadMessagesPage> => {
   const limit = Math.min(options.limit ?? DEFAULT_MESSAGE_PAGE_SIZE, MAX_MESSAGE_PAGE_SIZE)
 
-  const where: Prisma.MessageWhereInput = { threadId }
-  const andClauses: Prisma.MessageWhereInput[] = [
-    // Internal/hidden messages (e.g. the personal assistant's scheduled kickoff
-    // prompt) drive a run but are never rendered in the thread feed.
-    { NOT: { metadata: { path: ['hidden'], equals: true } } },
-  ]
+  // Internal `system`-role messages (e.g. the personal assistant's scheduled
+  // kickoff prompt) drive a run but are never rendered in the thread feed.
+  const where: Prisma.MessageWhereInput = { threadId, role: { not: 'system' } }
+  const andClauses: Prisma.MessageWhereInput[] = []
 
   if (options.before) {
     const parsed = parseMessageCursor(options.before)

--- a/docs/plans/2026-04-15-personal-assistant-mvp.md
+++ b/docs/plans/2026-04-15-personal-assistant-mvp.md
@@ -90,6 +90,18 @@ Special policies:
 - user-equivalent action scope: if the user can do it, the assistant can do it;
   if the user would need to delegate another agent, the assistant does that too
 
+> **Update (2026-06-11) — privileged delegate, org-wide reach.** The personal
+> assistant is treated as its owner's privileged delegate and reaches **every
+> channel in the organization** — not only public channels plus the ones the
+> owner has joined. It is exempt from the `AgentBinding` "is this bot a member of
+> the channel?" gate (both when scheduling a task and when the scheduled task
+> fires), because binding does not apply to a delegate that acts as the user.
+> Channel resolution (post/schedule/list), workspace + message search, and
+> curated-thought recall (`resolveAccessibleScopes` `personal_assistant` mode)
+> all resolve org-wide for the PA. This deliberately broadens the original
+> "same scope as the user" framing above; the gate is `agentKind =
+> personal_assistant`, so ordinary (`shared`) agents are unaffected.
+
 This keeps the MVP small and gives us a clean path to future managed assistants.
 
 ## 4. MVP Behavior
@@ -265,6 +277,15 @@ MVP policy should be explicit:
 - provenance remains available in audit and can be surfaced to the sender,
   admins, or later recipient-facing UI if product decides that trust tradeoff is
   worth exposing
+
+> **Update (2026-06-11) — scheduled posts are delegated too.** This author model
+> now applies to **scheduled** PA posts as well, not just immediate sends. When a
+> PA-owned scheduled task fires into a shared channel, the run's final message is
+> authored as the owner (`userId = owner`, `role = user`, `metadata`
+> `delegatedByAgentId` + `delegatedFromRunId`) instead of as the assistant bot.
+> The task's internal kickoff/instruction message is written with
+> `metadata.hidden = true` so it drives the run but never renders in the target
+> channel feed. PA replies **inside the PA DM** stay assistant-authored.
 
 ### `Agent` execution policy
 

--- a/docs/plans/2026-04-15-personal-assistant-mvp.md
+++ b/docs/plans/2026-04-15-personal-assistant-mvp.md
@@ -283,9 +283,11 @@ MVP policy should be explicit:
 > PA-owned scheduled task fires into a shared channel, the run's final message is
 > authored as the owner (`userId = owner`, `role = user`, `metadata`
 > `delegatedByAgentId` + `delegatedFromRunId`) instead of as the assistant bot.
-> The task's internal kickoff/instruction message is written with
-> `metadata.hidden = true` so it drives the run but never renders in the target
-> channel feed. PA replies **inside the PA DM** stay assistant-authored.
+> The task's internal kickoff/instruction message is written with `role = system`
+> so it drives the run but is excluded from both the channel feed
+> (`listThreadMessages`) and model context (`loadConversation`); shared agents
+> keep their visible `role = user` kickoff. PA replies **inside the PA DM** stay
+> assistant-authored.
 
 ### `Agent` execution policy
 

--- a/packages/memory/src/scopes.ts
+++ b/packages/memory/src/scopes.ts
@@ -136,13 +136,12 @@ const resolvePersonalAssistantScopes = async (
   userId: string,
 ): Promise<{ channelIds: string[]; teamIds: string[]; projectIds: string[] }> => {
   const [channels, teams, projects] = await Promise.all([
+    // The personal assistant is its owner's delegate and reaches every channel
+    // in the organization — not just public ones or ones the owner joined.
     db.query(
       `SELECT c.id FROM channels c
-       WHERE c.organization_id = $1
-         AND (c.visibility = 'public'
-              OR EXISTS (SELECT 1 FROM channel_members cm
-                         WHERE cm.channel_id = c.id AND cm.user_id = $2))`,
-      [organizationId, userId],
+       WHERE c.organization_id = $1`,
+      [organizationId],
     ),
     db.query(
       `SELECT t.id FROM teams t

--- a/packages/memory/test/scopes.test.ts
+++ b/packages/memory/test/scopes.test.ts
@@ -125,6 +125,36 @@ test('personal_assistant grants the user full accessible scope plus private memo
   assert.ok(pairs.some(([t, i]) => t === 'user' && i === USER))
 })
 
+test('personal_assistant reaches every channel in the org (no membership filter)', async () => {
+  let channelsSql = ''
+  const pool = createPoolStub((sql) => {
+    if (sql.includes('FROM channels c') && !sql.includes('agent_bindings')) {
+      channelsSql = sql
+      return { rows: [{ id: 'chan-private' }, { id: 'chan-public' }] }
+    }
+    if (sql.includes('FROM teams t') && sql.includes('JOIN projects p')) {
+      return { rows: [] }
+    }
+    if (sql.includes('FROM projects p') && !sql.includes('FROM teams')) {
+      return { rows: [] }
+    }
+    if (sql.includes('organization_members')) {
+      return { rowCount: 1, rows: [{}] }
+    }
+    throw new Error(`Unexpected query: ${sql}`)
+  })
+
+  const scopes = await resolveAccessibleScopes(
+    { agentId: AGENT, mode: 'personal_assistant', organizationId: ORG, userId: USER },
+    pool,
+  )
+
+  // Org-wide: the channels query must not filter by membership or visibility.
+  assert.ok(!channelsSql.includes('channel_members'))
+  assert.ok(!channelsSql.includes('visibility'))
+  assert.deepEqual(scopes.channelIds.sort(), ['chan-private', 'chan-public'])
+})
+
 test('autonomous is bound by the agent configured scope, with no user-private', async () => {
   const pool = createPoolStub((sql) => {
     if (sql.includes('JOIN agent_bindings')) {

--- a/worker/src/control/trigger-events.ts
+++ b/worker/src/control/trigger-events.ts
@@ -54,6 +54,7 @@ export const dispatchEventTriggers = async (
     select: {
       agent: {
         select: {
+          agentKind: true,
           organizationId: true,
           projectId: true,
           teamId: true,

--- a/worker/src/control/trigger-retry-dispatch.ts
+++ b/worker/src/control/trigger-retry-dispatch.ts
@@ -23,7 +23,13 @@ export const reattemptTriggerDelivery = async (
     where: { id: input.triggerId },
     include: {
       agent: {
-        select: { id: true, organizationId: true, projectId: true, teamId: true },
+        select: {
+          id: true,
+          agentKind: true,
+          organizationId: true,
+          projectId: true,
+          teamId: true,
+        },
       },
       workflowInstallation: {
         select: {
@@ -81,6 +87,7 @@ export const reattemptTriggerDelivery = async (
     source: input.source,
     trigger: {
       agent: {
+        agentKind: trigger.agent.agentKind,
         organizationId: trigger.agent.organizationId,
         projectId: trigger.agent.projectId,
         teamId: trigger.agent.teamId,

--- a/worker/src/control/trigger-run.ts
+++ b/worker/src/control/trigger-run.ts
@@ -376,18 +376,19 @@ export const queueTriggerRun = async (
       const message = await tx.message.create({
         data: {
           content,
-          // The personal assistant's scheduled kickoff prompt is an internal
-          // instruction, not a post the owner made; hide it from the target
-          // channel feed so only the assistant's owner-authored result shows.
+          // A PA-owned scheduled run posts AS the owner, so its kickoff prompt is
+          // an internal system-injected directive rather than a post the owner
+          // made. Mark it `system` so it drives the run but is excluded from both
+          // the channel feed and future model context (see listThreadMessages /
+          // loadConversation). Shared agents keep the visible `user` kickoff.
           ...(isPersonalAssistantTrigger
             ? {
                 metadata: {
-                  hidden: true,
                   delegatedByAgentId: input.trigger.agentId,
                 } as Prisma.InputJsonValue,
               }
             : {}),
-          role: 'user',
+          role: isPersonalAssistantTrigger ? 'system' : 'user',
           threadId: input.trigger.targetThreadId,
         },
         select: { id: true },

--- a/worker/src/control/trigger-run.ts
+++ b/worker/src/control/trigger-run.ts
@@ -271,6 +271,7 @@ export const queueTriggerRun = async (
     source: string
     trigger: {
       agent: {
+        agentKind: 'personal_assistant' | 'shared'
         organizationId: string | null
         projectId: string | null
         teamId: string | null
@@ -284,6 +285,11 @@ export const queueTriggerRun = async (
     }
   },
 ): Promise<void> => {
+  // The personal assistant is its owner's delegate: it reaches every channel in
+  // the organization, so the binding gate and the membership re-check below do
+  // not apply to it. It always keeps acting as its owner.
+  const isPersonalAssistantTrigger =
+    input.trigger.agent.agentKind === 'personal_assistant'
   const existingDelivery = input.dedupeKey
     ? await prisma.agentTriggerDelivery.findFirst({
         where: {
@@ -315,23 +321,31 @@ export const queueTriggerRun = async (
     return
   }
 
-  const binding = await prisma.agentBinding.findFirst({
-    where: {
-      agentId: input.trigger.agentId,
-      channelId: input.trigger.targetChannelId,
-    },
-    select: { id: true },
-  })
-  if (!binding) {
-    return
+  if (!isPersonalAssistantTrigger) {
+    const binding = await prisma.agentBinding.findFirst({
+      where: {
+        agentId: input.trigger.agentId,
+        channelId: input.trigger.targetChannelId,
+      },
+      select: { id: true },
+    })
+    if (!binding) {
+      return
+    }
   }
 
   // The scheduled run acts as the user who created it (config.createdByUserId).
   // Authorization for the target channel was checked at creation time; re-verify
   // here so a user later removed from a private channel can't keep the run acting
   // as them. If they've lost access, fall back to an autonomous (no-user) run.
+  // The personal assistant is exempt: it reaches every channel as its owner, so
+  // it keeps acting as the owner regardless of that user's channel membership.
   let effectiveUserId = extractTriggerEffectiveUserId(input.trigger.config)
-  if (effectiveUserId && thread.channel.visibility !== 'public') {
+  if (
+    !isPersonalAssistantTrigger
+    && effectiveUserId
+    && thread.channel.visibility !== 'public'
+  ) {
     const membership = await prisma.channelMember.findFirst({
       where: { channelId: input.trigger.targetChannelId, userId: effectiveUserId },
       select: { userId: true },
@@ -362,6 +376,17 @@ export const queueTriggerRun = async (
       const message = await tx.message.create({
         data: {
           content,
+          // The personal assistant's scheduled kickoff prompt is an internal
+          // instruction, not a post the owner made; hide it from the target
+          // channel feed so only the assistant's owner-authored result shows.
+          ...(isPersonalAssistantTrigger
+            ? {
+                metadata: {
+                  hidden: true,
+                  delegatedByAgentId: input.trigger.agentId,
+                } as Prisma.InputJsonValue,
+              }
+            : {}),
           role: 'user',
           threadId: input.trigger.targetThreadId,
         },

--- a/worker/src/control/trigger-scheduler.ts
+++ b/worker/src/control/trigger-scheduler.ts
@@ -113,6 +113,7 @@ export const sweepDueScheduledTriggers = async (
     select: {
       agent: {
         select: {
+          agentKind: true,
           organizationId: true,
           projectId: true,
           teamId: true,

--- a/worker/src/run/execute.ts
+++ b/worker/src/run/execute.ts
@@ -765,11 +765,14 @@ const publishMessageCreated = async (
     content: string
     messageId: string
     role: 'assistant' | 'system' | 'user'
+    // A delegated owner-authored post (the personal assistant acting for its
+    // owner) carries no agent author, mirroring a human-authored message.
+    authoredByOwner?: boolean
   },
 ): Promise<void> => {
   await realtimeTransport.publishWs(buildScopes(context), {
     data: {
-      agentId: parseAgentId(context.agent.id),
+      agentId: input.authoredByOwner ? undefined : parseAgentId(context.agent.id),
       channelId: parseChannelId(context.channel.id),
       contentPreview: input.content.slice(0, 200),
       messageId: input.messageId,
@@ -1381,6 +1384,7 @@ export const executeRunJob = async (
 
     const buildBuiltinCtx = (toolActorContext: AuthorizedActionContext) => ({
       agentId: context.agent.id,
+      agentKind: context.agent.agentKind,
       actorContext: toolActorContext,
       channel: {
         id: context.channel.id,
@@ -1569,13 +1573,37 @@ export const executeRunJob = async (
       await markRecallsReferenced(referencedRecallIds, deps.searchConfig.pool)
     }
 
+    // The personal assistant is its owner's delegate: anything it posts into a
+    // shared channel is authored as that owner (mirroring the immediate
+    // send_message tool), not as the assistant bot. Replies inside its own DM
+    // stay assistant-authored so the DM still renders the assistant.
+    const delegatedOwnerId =
+      context.agent.agentKind === 'personal_assistant'
+      && context.channel.systemChannelType !== 'personal_assistant'
+        ? payload.actorContext.actionContext.effectiveUserId
+          ?? (payload.actorContext.actor.actorType === 'user'
+            ? payload.actorContext.actor.actorId
+            : null)
+        : null
+
     const assistantMessage = await deps.prisma.message.create({
-      data: {
-        agentId: context.agent.id,
-        content: responseText,
-        role: 'assistant',
-        threadId: context.run.threadId,
-      },
+      data: delegatedOwnerId
+        ? {
+            content: responseText,
+            metadata: {
+              delegatedByAgentId: context.agent.id,
+              delegatedFromRunId: context.run.id,
+            } as Prisma.InputJsonValue,
+            role: 'user',
+            threadId: context.run.threadId,
+            userId: delegatedOwnerId,
+          }
+        : {
+            agentId: context.agent.id,
+            content: responseText,
+            role: 'assistant',
+            threadId: context.run.threadId,
+          },
     })
 
     await deps.realtimeTransport.publishSse(context.run.threadId, 'stream.done', {
@@ -1587,9 +1615,10 @@ export const executeRunJob = async (
     })
 
     await publishMessageCreated(deps.realtimeTransport, context, {
+      authoredByOwner: delegatedOwnerId !== null,
       content: responseText,
       messageId: assistantMessage.id,
-      role: 'assistant',
+      role: delegatedOwnerId ? 'user' : 'assistant',
     })
 
     await updateRunStatus(deps.prisma, context.run.id, 'completed')

--- a/worker/src/run/execute.ts
+++ b/worker/src/run/execute.ts
@@ -1112,7 +1112,10 @@ const loadConversation = async (
   threadId: string,
 ): Promise<StoredConversationMessage[]> => {
   const messages = await prisma.message.findMany({
-    where: { threadId },
+    // Exclude internal `system`-role messages (e.g. a PA scheduled kickoff
+    // prompt) so they never leak into the model's conversation window. The
+    // current run still receives its prompt directly via payload.messageId.
+    where: { threadId, role: { not: 'system' } },
     orderBy: { createdAt: 'desc' },
     select: {
       content: true,

--- a/worker/src/run/pa-tools.ts
+++ b/worker/src/run/pa-tools.ts
@@ -100,9 +100,7 @@ const resolveAccessibleChannelIds = async (
 
   const effectiveUserId = resolveEffectiveUserId(context)
 
-  const isPersonalAssistant =
-    context.agentKind === 'personal_assistant'
-    || context.channel.systemChannelType === 'personal_assistant'
+  const isPersonalAssistant = context.agentKind === 'personal_assistant'
 
   // The personal assistant acts as its owner; without one there is nothing to
   // act as, so it sees nothing.

--- a/worker/src/run/pa-tools.ts
+++ b/worker/src/run/pa-tools.ts
@@ -10,7 +10,6 @@ import {
   parseOrganizationId,
   parseThreadId,
   parseUserId,
-  type AuthorizedActionContext,
 } from '@nessie/schemas'
 import { randomUUID } from 'node:crypto'
 import { loadConfig } from '@nessie/config'
@@ -39,18 +38,52 @@ const clampLimit = (value: unknown, fallback: number): number => {
   return Math.min(Math.max(Math.trunc(parsed), 1), 20)
 }
 
-const requireUserActor = (actorContext: AuthorizedActionContext): string => {
-  if (actorContext.actor.actorType !== 'user') {
+// The user this run acts on behalf of: the actor itself for an interactive
+// (user-actor) run, or the delegated effectiveUserId when an agent acts for a
+// user (the personal assistant acting for its owner). Null when there is no
+// user to act as.
+const resolveEffectiveUserId = (
+  context: BuiltinToolRuntimeContext,
+): string | null =>
+  context.actorContext.actionContext.effectiveUserId
+  ?? (context.actorContext.actor.actorType === 'user'
+    ? context.actorContext.actor.actorId
+    : null)
+
+// The personal assistant is a privileged delegate of its owner: it acts as that
+// user across every channel in the organization. True only when this run is the
+// PA and it has an owner to act as.
+export const isDelegatingPersonalAssistant = (
+  context: BuiltinToolRuntimeContext,
+): boolean =>
+  context.agentKind === 'personal_assistant'
+  && resolveEffectiveUserId(context) !== null
+
+// The user id a tool acts as: the user actor for an interactive run, or the
+// delegated owner for the personal assistant's runs. Throws when neither exists
+// (a non-delegating agent has no user to act as).
+const requireActingUserId = (context: BuiltinToolRuntimeContext): string => {
+  const userId = resolveEffectiveUserId(context)
+  if (!userId) {
     throw new Error('This tool requires a user actor context.')
   }
-
-  return actorContext.actor.actorId
+  return userId
 }
 
-const buildVisibleChannelWhere = (organizationId: string, userId: string) => ({
-  organizationId,
-  OR: [{ visibility: 'public' as const }, { members: { some: { userId } } }],
-})
+// Channels a delegated run may target. The personal assistant reaches every
+// channel in the organization (it is its owner's delegate); everyone else is
+// scoped to public channels plus the ones the acting user belongs to.
+const buildVisibleChannelWhere = (
+  organizationId: string,
+  userId: string,
+  orgWide = false,
+): Prisma.ChannelWhereInput =>
+  orgWide
+    ? { organizationId }
+    : {
+        organizationId,
+        OR: [{ visibility: 'public' }, { members: { some: { userId } } }],
+      }
 
 // The set of channels an agent run may search past conversations in. Shares
 // the exact access model used for curated-memory recall, so search can never
@@ -65,14 +98,11 @@ const resolveAccessibleChannelIds = async (
     )
   }
 
-  const effectiveUserId =
-    context.actorContext.actionContext.effectiveUserId
-    ?? (context.actorContext.actor.actorType === 'user'
-      ? context.actorContext.actor.actorId
-      : undefined)
+  const effectiveUserId = resolveEffectiveUserId(context)
 
   const isPersonalAssistant =
-    context.channel.systemChannelType === 'personal_assistant'
+    context.agentKind === 'personal_assistant'
+    || context.channel.systemChannelType === 'personal_assistant'
 
   // The personal assistant acts as its owner; without one there is nothing to
   // act as, so it sees nothing.
@@ -310,8 +340,9 @@ const resolveMessageDestination = async (
   threadId: string
   threadLabel: string | null
 }> => {
-  const userId = requireUserActor(context.actorContext)
+  const userId = requireActingUserId(context)
   const organizationId = context.channel.organizationId
+  const orgWide = isDelegatingPersonalAssistant(context)
   const explicitDestinationCount = [
     input.threadId ? 1 : 0,
     input.channelId ? 1 : 0,
@@ -360,7 +391,7 @@ const resolveMessageDestination = async (
     const channel = await context.prisma.channel.findFirst({
       where: {
         id: input.channelId,
-        ...buildVisibleChannelWhere(organizationId, userId),
+        ...buildVisibleChannelWhere(organizationId, userId, orgWide),
       },
       select: {
         id: true,
@@ -400,7 +431,7 @@ const resolveMessageDestination = async (
     const thread = await context.prisma.thread.findFirst({
       where: {
         id: input.threadId,
-        channel: buildVisibleChannelWhere(organizationId, userId),
+        channel: buildVisibleChannelWhere(organizationId, userId, orgWide),
       },
       select: {
         id: true,
@@ -441,7 +472,7 @@ const resolveMessageDestination = async (
   const thread = await context.prisma.thread.findFirst({
     where: {
       id: fallbackThreadId,
-      channel: buildVisibleChannelWhere(organizationId, userId),
+      channel: buildVisibleChannelWhere(organizationId, userId, orgWide),
     },
     select: {
       id: true,
@@ -684,7 +715,11 @@ export const runAuthoredMessageSearchTool = async (
   }
 
   const take = clampLimit(limit, MAX_SEARCH_RESULTS)
-  const visibleChannelWhere = buildVisibleChannelWhere(context.channel.organizationId, userId)
+  const visibleChannelWhere = buildVisibleChannelWhere(
+    context.channel.organizationId,
+    userId,
+    isDelegatingPersonalAssistant(context),
+  )
   const textFilter = { contains: searchQuery, mode: 'insensitive' as const }
 
   const messages = await context.prisma.message.findMany({
@@ -770,7 +805,7 @@ export const runPeopleSearchTool = async (
 
   const lines = people.map((person, index) => {
     const role = person.organizationMembers[0]?.role ?? 'member'
-    const youLabel = person.id === requireUserActor(context.actorContext) ? ' (you)' : ''
+    const youLabel = person.id === requireActingUserId(context) ? ' (you)' : ''
     return `${index + 1}. ${person.displayName}${youLabel} <${person.email}> | userId=${person.id} | role=${role}`
   })
 
@@ -791,7 +826,7 @@ export const runUpdatePreferencesTool = async (
     throw new Error('preferences must be a non-empty object.')
   }
 
-  const userId = requireUserActor(context.actorContext)
+  const userId = requireActingUserId(context)
   const updatedUser = await context.prisma.user.update({
     where: { id: parseUserId(userId) },
     data: { preferences: preferences as Prisma.InputJsonValue },
@@ -819,7 +854,7 @@ export const runSendMessageTool = async (
     threadId?: string
   },
 ): Promise<ToolExecutionResult> => {
-  const userId = requireUserActor(context.actorContext)
+  const userId = requireActingUserId(context)
   const content = input.content.trim()
   if (!content) {
     throw new Error('content is required.')
@@ -1175,7 +1210,7 @@ export const runAttachmentListTool = async (
   // back to the run's own thread.
   const threadId = input.threadId ?? (input.channelId ? undefined : context.run.threadId)
   const visibleChannel = userId
-    ? buildVisibleChannelWhere(organizationId, userId)
+    ? buildVisibleChannelWhere(organizationId, userId, isDelegatingPersonalAssistant(context))
     : { organizationId }
 
   const messageWhere = input.channelId
@@ -1326,13 +1361,13 @@ export const runChannelListTool = async (
   context: BuiltinToolRuntimeContext,
   input: { includeArchived?: boolean; limit?: unknown },
 ): Promise<ToolExecutionResult> => {
-  const userId = requireUserActor(context.actorContext)
+  const userId = requireActingUserId(context)
   const organizationId = context.channel.organizationId
   const take = clampLimit(input.limit, 20)
 
   const channels = await context.prisma.channel.findMany({
     where: {
-      ...buildVisibleChannelWhere(organizationId, userId),
+      ...buildVisibleChannelWhere(organizationId, userId, isDelegatingPersonalAssistant(context)),
       ...(input.includeArchived ? {} : { archivedAt: null }),
     },
     orderBy: { createdAt: 'asc' },
@@ -1369,7 +1404,7 @@ export const runChannelUpdateTool = async (
     description?: string
   },
 ): Promise<ToolExecutionResult> => {
-  const userId = requireUserActor(context.actorContext)
+  const userId = requireActingUserId(context)
   const organizationId = context.channel.organizationId
   if (!input.channelId) {
     throw new Error('channelId is required.')
@@ -1428,7 +1463,7 @@ export const runChannelArchiveTool = async (
   context: BuiltinToolRuntimeContext,
   input: { channelId: string; archived?: boolean },
 ): Promise<ToolExecutionResult> => {
-  const userId = requireUserActor(context.actorContext)
+  const userId = requireActingUserId(context)
   const organizationId = context.channel.organizationId
   if (!input.channelId) {
     throw new Error('channelId is required.')
@@ -1462,7 +1497,7 @@ export const runChannelJoinTool = async (
   context: BuiltinToolRuntimeContext,
   input: { channelId: string },
 ): Promise<ToolExecutionResult> => {
-  const userId = requireUserActor(context.actorContext)
+  const userId = requireActingUserId(context)
   const organizationId = context.channel.organizationId
   if (!input.channelId) {
     throw new Error('channelId is required.')

--- a/worker/src/run/schedule-tools.test.ts
+++ b/worker/src/run/schedule-tools.test.ts
@@ -81,9 +81,13 @@ const makeFakePrisma = (overrides: {
   }
 }
 
-const makeContext = (prisma: FakePrisma): BuiltinToolRuntimeContext =>
+const makeContext = (
+  prisma: FakePrisma,
+  overrides: { agentKind?: 'personal_assistant' | 'shared' } = {},
+): BuiltinToolRuntimeContext =>
   ({
     agentId: 'agent-1',
+    agentKind: overrides.agentKind ?? 'shared',
     actorContext: {
       actor: { actorId: 'user-1', actorType: 'user', roles: [] },
       actionContext: {},
@@ -224,6 +228,33 @@ test('schedule_task into another channel requires the agent to be a member', asy
       }),
     /not a member/,
   )
+})
+
+test('schedule_task: personal assistant reaches any channel without a binding', async () => {
+  const prisma = makeFakePrisma({
+    channel: { id: 'channel-2', label: 'general' },
+    thread: { id: 'thread-2' },
+    binding: null, // unbound — must not matter for the personal assistant
+  })
+  const result = await runScheduleTaskTool(
+    makeContext(prisma, { agentKind: 'personal_assistant' }),
+    {
+      instructions: 'post the weekly update',
+      schedule: { kind: 'interval', every_minutes: 60 },
+      target: 'general',
+    },
+  )
+
+  assert.equal(result.toolName, 'schedule_task')
+  const create = (prisma.calls['agentTrigger.create'] as Array<{ data: Record<string, unknown> }>)[0]!
+  assert.equal(create.data.targetChannelId, 'channel-2')
+  // No binding lookup: the personal assistant is its owner's delegate.
+  assert.equal(prisma.calls['agentBinding.findFirst'], undefined)
+  // Channel resolution is org-wide (no public/membership access clause).
+  const lookup = (
+    prisma.calls['channel.findFirst'] as Array<{ where: { AND: Array<Record<string, unknown>> } }>
+  )[0]!
+  assert.deepEqual(lookup.where.AND[0], { organizationId: 'org-1' })
 })
 
 test('schedule_task into another channel succeeds when bound', async () => {

--- a/worker/src/run/schedule-tools.ts
+++ b/worker/src/run/schedule-tools.ts
@@ -1,6 +1,7 @@
 import { Prisma } from '@prisma/client'
 import { computeInitialScheduleRunAt } from '@nessie/runtime'
 import type { AgentTriggerType } from '@nessie/schemas'
+import { isDelegatingPersonalAssistant } from './pa-tools.js'
 import type { BuiltinToolRuntimeContext, ToolExecutionResult } from './tool-types.js'
 
 const UUID_PATTERN =
@@ -95,13 +96,16 @@ const parseSchedule = (raw: unknown): ParsedSchedule => {
 const visibleChannelWhere = (
   organizationId: string,
   userId: string | null,
+  orgWide: boolean,
 ): Prisma.ChannelWhereInput =>
-  userId
-    ? {
-        organizationId,
-        OR: [{ visibility: 'public' }, { members: { some: { userId } } }],
-      }
-    : { organizationId, visibility: 'public' }
+  orgWide
+    ? { organizationId }
+    : userId
+      ? {
+          organizationId,
+          OR: [{ visibility: 'public' }, { members: { some: { userId } } }],
+        }
+      : { organizationId, visibility: 'public' }
 
 type ResolvedTarget = {
   channelId: string
@@ -131,7 +135,11 @@ const resolveTarget = async (
   const channel = await context.prisma.channel.findFirst({
     where: {
       AND: [
-        visibleChannelWhere(context.channel.organizationId, userId),
+        visibleChannelWhere(
+          context.channel.organizationId,
+          userId,
+          isDelegatingPersonalAssistant(context),
+        ),
         UUID_PATTERN.test(target)
           ? { id: target }
           : { label: { equals: target, mode: 'insensitive' } },
@@ -180,7 +188,12 @@ export const runScheduleTaskTool = async (
 
   // Posting into a channel other than the current one requires the agent to be a
   // member there, mirroring the binding check the scheduler enforces at fire time.
-  if (target.channelId !== context.channel.id) {
+  // The personal assistant is exempt: it is its owner's delegate and reaches
+  // every channel in the organization, so binding does not apply to it.
+  if (
+    target.channelId !== context.channel.id
+    && !isDelegatingPersonalAssistant(context)
+  ) {
     const binding = await context.prisma.agentBinding.findFirst({
       where: { agentId: context.agentId, channelId: target.channelId },
       select: { id: true },

--- a/worker/src/run/tool-types.ts
+++ b/worker/src/run/tool-types.ts
@@ -11,6 +11,7 @@ export type ToolExecutionResult = {
 
 export type BuiltinToolRuntimeContext = {
   agentId: string
+  agentKind: 'personal_assistant' | 'shared'
   actorContext: RunExecuteJobPayload['actorContext']
   channel: {
     id: string


### PR DESCRIPTION
## Problem

The Personal Assistant (PA) was gated like an ordinary scoped bot. An `AgentBinding` "is this bot a member of the channel?" check blocked it from posting/scheduling into channels (e.g. `#general` — the bug the user hit), its reach was capped at public + channels the owner had joined, and its **scheduled** output was authored as the bot rather than the owner.

The owner's requirement: the PA is their delegate — it should reach **every channel in the org** and post **as them**.

## What changed

All behavior is gated on `agentKind === 'personal_assistant'`, so ordinary (`shared`) agents are unchanged.

- **Org-wide reach** — channel resolution (post/schedule/list), workspace + message search, and curated-thought recall (`resolvePersonalAssistantScopes`) resolve to every channel in the org for the PA.
- **Binding gate removed for the PA** — at schedule-creation (`schedule-tools.ts`) and at fire time (`trigger-run.ts`); the PA also keeps acting as its owner (no `effectiveUserId` nulling). `agentKind` is threaded through the three trigger callers.
- **Posts authored as the owner** — scheduled PA output into a shared channel is written as `userId = owner`, `role = user`, `metadata.delegatedByAgentId/delegatedFromRunId` (matching the existing immediate `send_message`). PA replies inside its own DM stay assistant-authored.
- **Kickoff hidden via `role: 'system'`** — the scheduled instruction message drives the run but is excluded from the channel feed (`listThreadMessages`) and model context (`loadConversation`). (Initial `metadata.hidden` JSON-path approach was replaced after a live DB test showed Prisma's three-valued logic dropped *all* messages.)
- **`requireUserActor` → `requireActingUserId`** so scheduled PA runs (actor = agent) can still use owner-actor tools via `effectiveUserId`.

## Verification

- Build (tsc) + ESLint clean across `@nessie/worker`, `@nessie/memory`, `@nessie/api`.
- Unit tests: worker 77/77, memory 14/14 (1 pre-existing skip). New tests: PA schedules into an unbound channel with **no** binding lookup + org-wide channel `where`; PA memory scope returns all org channels.
- **Live Postgres test** of the thread-feed filter: `role: { not: 'system' }` keeps all 2631 real messages and excludes only the system kickoff. (The original `metadata.hidden` filter dropped all 2631 — caught and fixed.)
- Reviewed by a code-reviewer agent; all findings verified against source and addressed.

## Known limitation

Event-type triggers (`trigger-events.ts`) don't pass `config` to `queueTriggerRun` (pre-existing on `main`), so a PA *event* trigger would run without owner delegation. The PA can only create `scheduled`/`interval` triggers (via `schedule_task` → `trigger-scheduler`, which does pass `config`), so the scheduled-post feature is unaffected. Left as-is to avoid changing shared-agent event behavior.

## Docs

`docs/plans/2026-04-15-personal-assistant-mvp.md` updated with the org-wide-reach and delegated-scheduled-post decisions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)