### PR TITLE
Merge useful worker PRs

### DIFF
--- a/worker/src/run/agentic-loop.ts
+++ b/worker/src/run/agentic-loop.ts
@@ -17,6 +17,7 @@ import {
   estimateToolSchemaTokens,
   trimConversationToFit,
 } from './context-management.js'
+import { ToolCircuitBreaker } from './circuit-breaker.js'
 import { summarizeToolInput } from './tool-util.js'
 
 export type BudgetLimits = {
@@ -192,6 +193,7 @@ export const runAgenticLoop = async (input: {
   const signatureCounts = new Map<string, number>()
   const retryBudget = createRetryBudget(6)
   const toolSchemaTokens = estimateToolSchemaTokens(input.tools)
+  const circuitBreaker = new ToolCircuitBreaker()
 
   let iterations = 0
   let toolCallsUsed = 0
@@ -304,6 +306,16 @@ export const runAgenticLoop = async (input: {
           }
         }
 
+        if (circuitBreaker.isTripped(tc.toolName)) {
+          return {
+            output: circuitBreaker.trippedErrorMessage(tc.toolName),
+            success: false,
+            inputSummary: summarizeToolInput(tc.arguments),
+            toolCallId: tc.toolCallId,
+            toolName: tc.toolName,
+          }
+        }
+
         await callbacks.onToolCallStart(tc.toolName, tc.arguments)
         const startedAt = new Date()
 
@@ -314,6 +326,11 @@ export const runAgenticLoop = async (input: {
             tc.toolName,
           )
           const durationMs = Date.now() - startedAt.getTime()
+          if (toolResult.success) {
+            circuitBreaker.recordSuccess(tc.toolName)
+          } else {
+            circuitBreaker.recordError(tc.toolName)
+          }
           await callbacks.onToolCallEnd(
             tc.toolName,
             toolResult.output,
@@ -326,6 +343,7 @@ export const runAgenticLoop = async (input: {
           return { ...toolResult, toolCallId: tc.toolCallId, toolName: tc.toolName }
         } catch (error) {
           const errorMsg = error instanceof Error ? error.message : 'Tool execution failed'
+          circuitBreaker.recordError(tc.toolName)
           const durationMs = Date.now() - startedAt.getTime()
           await callbacks.onToolCallEnd(
             tc.toolName,

--- a/worker/src/run/builtin-handlers/file-glob.ts
+++ b/worker/src/run/builtin-handlers/file-glob.ts
@@ -125,7 +125,7 @@ const walkGlob = async (
       }
       const child = join(cwd, entry.name)
       try {
-        await assertInsideSandbox(child, sandbox, TOOL_ID)
+        await assertInsideSandbox(child, sandbox, TOOL_ID, 'read')
       } catch {
         continue
       }
@@ -161,7 +161,7 @@ const walkGlob = async (
     }
     const childPath = join(cwd, entry.name)
     try {
-      await assertInsideSandbox(childPath, sandbox, TOOL_ID)
+      await assertInsideSandbox(childPath, sandbox, TOOL_ID, 'read')
     } catch {
       continue
     }
@@ -198,13 +198,13 @@ export const runFileGlob = async (
 ): Promise<FileGlobOutput> => {
   const input = InputSchema.parse(rawArgs)
   const sandbox = await extractSandboxConfig(transportConfig, TOOL_ID)
-  const candidateCwd = input.cwd ?? sandbox.allowedRoots[0]
+  const candidateCwd = input.cwd ?? sandbox.allowedRoots[0]?.path
   if (candidateCwd === undefined) {
     // extractSandboxConfig already guarantees at least one root, but keep this
     // explicit for the type narrowing.
     throw new Error('file_glob requires at least one allowed root.')
   }
-  const cwd = await assertInsideSandbox(candidateCwd, sandbox, TOOL_ID)
+  const cwd = await assertInsideSandbox(candidateCwd, sandbox, TOOL_ID, 'read')
   const limit = input.limit ?? DEFAULT_LIMIT
   const segments = compilePattern(input.pattern)
 

--- a/worker/src/run/builtin-handlers/file-read.ts
+++ b/worker/src/run/builtin-handlers/file-read.ts
@@ -29,7 +29,7 @@ export const runFileRead = async (
 ): Promise<FileReadOutput> => {
   const input = InputSchema.parse(rawArgs)
   const sandbox = await extractSandboxConfig(transportConfig, TOOL_ID)
-  const resolvedPath = await assertInsideSandbox(input.path, sandbox, TOOL_ID)
+  const resolvedPath = await assertInsideSandbox(input.path, sandbox, TOOL_ID, 'read')
   const maxBytes = input.maxBytes ?? DEFAULT_MAX_BYTES
 
   const handle = await open(resolvedPath, 'r')

--- a/worker/src/run/builtin-handlers/file-write.ts
+++ b/worker/src/run/builtin-handlers/file-write.ts
@@ -48,7 +48,7 @@ export const runFileWrite = async (
 ): Promise<FileWriteOutput> => {
   const input = InputSchema.parse(rawArgs)
   const sandbox = await extractSandboxConfig(transportConfig, TOOL_ID)
-  const resolvedPath = await assertInsideSandbox(input.path, sandbox, TOOL_ID)
+  const resolvedPath = await assertInsideSandbox(input.path, sandbox, TOOL_ID, 'write')
 
   const existed = await pathExists(resolvedPath)
   if (existed && !input.overwrite) {
@@ -59,7 +59,7 @@ export const runFileWrite = async (
 
   if (input.createParents) {
     const parent = dirname(resolvedPath)
-    await assertInsideSandbox(parent, sandbox, TOOL_ID)
+    await assertInsideSandbox(parent, sandbox, TOOL_ID, 'write')
     await mkdir(parent, { recursive: true })
   }
 

--- a/worker/src/run/builtin-handlers/index.ts
+++ b/worker/src/run/builtin-handlers/index.ts
@@ -27,4 +27,8 @@ export {
   extractSandboxConfig,
   SandboxViolationError,
   type SandboxConfig,
+  type SandboxRoot,
+  type SandboxRootKind,
+  type SandboxRootAccess,
+  type OperationType,
 } from './sandbox.js'

--- a/worker/src/run/builtin-handlers/sandbox.test.ts
+++ b/worker/src/run/builtin-handlers/sandbox.test.ts
@@ -5,7 +5,6 @@ import {
   rm,
   symlink,
   writeFile,
-  mkdir,
 } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
@@ -16,6 +15,14 @@ import {
   extractSandboxConfig,
   SandboxViolationError,
 } from './sandbox.js'
+
+const firstAllowedRoot = (
+  config: Awaited<ReturnType<typeof extractSandboxConfig>>,
+) => {
+  const [root] = config.allowedRoots
+  assert.ok(root)
+  return root
+}
 
 const setupDir = async (): Promise<{
   root: string
@@ -36,9 +43,10 @@ test('extractSandboxConfig accepts legacy string[] and normalizes defaults', asy
   try {
     const config = await extractSandboxConfig({ allowedRoots: [root] }, 'test')
     assert.equal(config.allowedRoots.length, 1)
-    assert.equal(config.allowedRoots[0].path, root)
-    assert.equal(config.allowedRoots[0].kind, 'dir')
-    assert.equal(config.allowedRoots[0].access, 'rw')
+    const allowedRoot = firstAllowedRoot(config)
+    assert.equal(allowedRoot.path, root)
+    assert.equal(allowedRoot.kind, 'dir')
+    assert.equal(allowedRoot.access, 'rw')
   } finally {
     await cleanup()
   }
@@ -53,8 +61,9 @@ test('extractSandboxConfig parses object entries with explicit kind and access',
       { allowedRoots: [{ path: root, kind: 'dir', access: 'ro' }] },
       'test',
     )
-    assert.equal(config.allowedRoots[0].kind, 'dir')
-    assert.equal(config.allowedRoots[0].access, 'ro')
+    const allowedRoot = firstAllowedRoot(config)
+    assert.equal(allowedRoot.kind, 'dir')
+    assert.equal(allowedRoot.access, 'ro')
   } finally {
     await cleanup()
   }
@@ -67,8 +76,9 @@ test('extractSandboxConfig defaults missing kind to dir and access to rw', async
       { allowedRoots: [{ path: root }] },
       'test',
     )
-    assert.equal(config.allowedRoots[0].kind, 'dir')
-    assert.equal(config.allowedRoots[0].access, 'rw')
+    const allowedRoot = firstAllowedRoot(config)
+    assert.equal(allowedRoot.kind, 'dir')
+    assert.equal(allowedRoot.access, 'rw')
   } finally {
     await cleanup()
   }
@@ -110,8 +120,9 @@ test('extractSandboxConfig validates file kind against actual filesystem type', 
       { allowedRoots: [{ path: filePath, kind: 'file', access: 'ro' }] },
       'test',
     )
-    assert.equal(config.allowedRoots[0].kind, 'file')
-    assert.equal(config.allowedRoots[0].access, 'ro')
+    const allowedRoot = firstAllowedRoot(config)
+    assert.equal(allowedRoot.kind, 'file')
+    assert.equal(allowedRoot.access, 'ro')
   } finally {
     await cleanup()
   }

--- a/worker/src/run/builtin-handlers/sandbox.test.ts
+++ b/worker/src/run/builtin-handlers/sandbox.test.ts
@@ -101,6 +101,36 @@ test('extractSandboxConfig rejects object without path string', async () => {
   )
 })
 
+test('extractSandboxConfig rejects invalid object kind', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    await assert.rejects(
+      extractSandboxConfig(
+        { allowedRoots: [{ path: root, kind: 'directory' }] },
+        'test',
+      ),
+      SandboxViolationError,
+    )
+  } finally {
+    await cleanup()
+  }
+})
+
+test('extractSandboxConfig rejects invalid object access', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    await assert.rejects(
+      extractSandboxConfig(
+        { allowedRoots: [{ path: root, access: 'read' }] },
+        'test',
+      ),
+      SandboxViolationError,
+    )
+  } finally {
+    await cleanup()
+  }
+})
+
 test('extractSandboxConfig rejects mixed invalid entry', async () => {
   await assert.rejects(
     extractSandboxConfig({ allowedRoots: [42] }, 'test'),

--- a/worker/src/run/builtin-handlers/sandbox.test.ts
+++ b/worker/src/run/builtin-handlers/sandbox.test.ts
@@ -1,0 +1,390 @@
+import assert from 'node:assert/strict'
+import {
+  mkdtemp,
+  realpath,
+  rm,
+  symlink,
+  writeFile,
+  mkdir,
+} from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import test from 'node:test'
+
+import {
+  assertInsideSandbox,
+  extractSandboxConfig,
+  SandboxViolationError,
+} from './sandbox.js'
+
+const setupDir = async (): Promise<{
+  root: string
+  cleanup: () => Promise<void>
+}> => {
+  const created = await mkdtemp(join(tmpdir(), 'nessie-sandbox-'))
+  const root = await realpath(created)
+  return {
+    root,
+    cleanup: () => rm(root, { recursive: true, force: true }),
+  }
+}
+
+// ── Legacy string-array backward compatibility ─────────────────────────────
+
+test('extractSandboxConfig accepts legacy string[] and normalizes defaults', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const config = await extractSandboxConfig({ allowedRoots: [root] }, 'test')
+    assert.equal(config.allowedRoots.length, 1)
+    assert.equal(config.allowedRoots[0].path, root)
+    assert.equal(config.allowedRoots[0].kind, 'dir')
+    assert.equal(config.allowedRoots[0].access, 'rw')
+  } finally {
+    await cleanup()
+  }
+})
+
+// ── Object format parsing ─────────────────────────────────────────────────
+
+test('extractSandboxConfig parses object entries with explicit kind and access', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: root, kind: 'dir', access: 'ro' }] },
+      'test',
+    )
+    assert.equal(config.allowedRoots[0].kind, 'dir')
+    assert.equal(config.allowedRoots[0].access, 'ro')
+  } finally {
+    await cleanup()
+  }
+})
+
+test('extractSandboxConfig defaults missing kind to dir and access to rw', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: root }] },
+      'test',
+    )
+    assert.equal(config.allowedRoots[0].kind, 'dir')
+    assert.equal(config.allowedRoots[0].access, 'rw')
+  } finally {
+    await cleanup()
+  }
+})
+
+test('extractSandboxConfig rejects non-existent object path', async () => {
+  await assert.rejects(
+    extractSandboxConfig(
+      { allowedRoots: [{ path: '/tmp/does-not-exist-12345' }] },
+      'test',
+    ),
+    SandboxViolationError,
+  )
+})
+
+test('extractSandboxConfig rejects object without path string', async () => {
+  await assert.rejects(
+    extractSandboxConfig({ allowedRoots: [{}] }, 'test'),
+    SandboxViolationError,
+  )
+})
+
+test('extractSandboxConfig rejects mixed invalid entry', async () => {
+  await assert.rejects(
+    extractSandboxConfig({ allowedRoots: [42] }, 'test'),
+    SandboxViolationError,
+  )
+})
+
+// ── File kind validation ───────────────────────────────────────────────────
+
+test('extractSandboxConfig validates file kind against actual filesystem type', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const filePath = join(root, 'config.json')
+    await writeFile(filePath, '{}', 'utf8')
+
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: filePath, kind: 'file', access: 'ro' }] },
+      'test',
+    )
+    assert.equal(config.allowedRoots[0].kind, 'file')
+    assert.equal(config.allowedRoots[0].access, 'ro')
+  } finally {
+    await cleanup()
+  }
+})
+
+test('extractSandboxConfig rejects file kind when path is a directory', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    await assert.rejects(
+      extractSandboxConfig(
+        { allowedRoots: [{ path: root, kind: 'file' }] },
+        'test',
+      ),
+      SandboxViolationError,
+    )
+  } finally {
+    await cleanup()
+  }
+})
+
+// ── Access mode enforcement ──────────────────────────────────────────────────
+
+test('assertInsideSandbox allows read on ro root', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: root, access: 'ro' }] },
+      'test',
+    )
+    const resolved = await assertInsideSandbox(
+      join(root, 'a.txt'),
+      config,
+      'test',
+      'read',
+    )
+    assert.ok(resolved.startsWith(root))
+  } finally {
+    await cleanup()
+  }
+})
+
+test('assertInsideSandbox rejects write on ro root', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: root, access: 'ro' }] },
+      'test',
+    )
+    await assert.rejects(
+      assertInsideSandbox(join(root, 'a.txt'), config, 'test', 'write'),
+      SandboxViolationError,
+    )
+  } finally {
+    await cleanup()
+  }
+})
+
+test('assertInsideSandbox allows write on rw root', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: root, access: 'rw' }] },
+      'test',
+    )
+    const resolved = await assertInsideSandbox(
+      join(root, 'a.txt'),
+      config,
+      'test',
+      'write',
+    )
+    assert.ok(resolved.startsWith(root))
+  } finally {
+    await cleanup()
+  }
+})
+
+test('assertInsideSandbox allows read on rw root', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: root, access: 'rw' }] },
+      'test',
+    )
+    const resolved = await assertInsideSandbox(
+      join(root, 'a.txt'),
+      config,
+      'test',
+      'read',
+    )
+    assert.ok(resolved.startsWith(root))
+  } finally {
+    await cleanup()
+  }
+})
+
+// ── File kind enforcement ──────────────────────────────────────────────────
+
+test('assertInsideSandbox allows exact path match for file root', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const filePath = join(root, 'config.json')
+    await writeFile(filePath, '{}', 'utf8')
+
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: filePath, kind: 'file', access: 'ro' }] },
+      'test',
+    )
+    const resolved = await assertInsideSandbox(
+      filePath,
+      config,
+      'test',
+      'read',
+    )
+    assert.equal(resolved, filePath)
+  } finally {
+    await cleanup()
+  }
+})
+
+test('assertInsideSandbox rejects sub-path for file root', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const filePath = join(root, 'config.json')
+    await writeFile(filePath, '{}', 'utf8')
+
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: filePath, kind: 'file', access: 'ro' }] },
+      'test',
+    )
+    await assert.rejects(
+      assertInsideSandbox(
+        join(root, 'config.json.backup'),
+        config,
+        'test',
+        'read',
+      ),
+      SandboxViolationError,
+    )
+  } finally {
+    await cleanup()
+  }
+})
+
+// ── Symlink escape still blocked ────────────────────────────────────────────
+
+test('assertInsideSandbox rejects symlink escape regardless of access mode', async () => {
+  const { root, cleanup } = await setupDir()
+  const escapeTarget = await mkdtemp(join(tmpdir(), 'nessie-sandbox-out-'))
+  try {
+    const secret = join(escapeTarget, 'secret.txt')
+    await writeFile(secret, 'leak', 'utf8')
+
+    const linkPath = join(root, 'link.txt')
+    await symlink(secret, linkPath)
+
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: root, access: 'rw' }] },
+      'test',
+    )
+    await assert.rejects(
+      assertInsideSandbox(linkPath, config, 'test', 'read'),
+      SandboxViolationError,
+    )
+  } finally {
+    await rm(escapeTarget, { recursive: true, force: true })
+    await cleanup()
+  }
+})
+
+// ── Multiple roots with different modes ────────────────────────────────────
+
+test('assertInsideSandbox picks correct root for mixed modes', async () => {
+  const { root: rwRoot, cleanup: cleanupRw } = await setupDir()
+  const { root: roRoot, cleanup: cleanupRo } = await setupDir()
+  try {
+    const config = await extractSandboxConfig(
+      {
+        allowedRoots: [
+          { path: rwRoot, access: 'rw' },
+          { path: roRoot, access: 'ro' },
+        ],
+      },
+      'test',
+    )
+
+    // Write allowed in rw root
+    const w = await assertInsideSandbox(
+      join(rwRoot, 'w.txt'),
+      config,
+      'test',
+      'write',
+    )
+    assert.ok(w.startsWith(rwRoot))
+
+    // Write rejected in ro root
+    await assert.rejects(
+      assertInsideSandbox(join(roRoot, 'w.txt'), config, 'test', 'write'),
+      SandboxViolationError,
+    )
+
+    // Read allowed in both
+    const r1 = await assertInsideSandbox(
+      join(rwRoot, 'r.txt'),
+      config,
+      'test',
+      'read',
+    )
+    assert.ok(r1.startsWith(rwRoot))
+    const r2 = await assertInsideSandbox(
+      join(roRoot, 'r.txt'),
+      config,
+      'test',
+      'read',
+    )
+    assert.ok(r2.startsWith(roRoot))
+  } finally {
+    await cleanupRw()
+    await cleanupRo()
+  }
+})
+
+// ── Empty/missing allowedRoots still rejected ──────────────────────────────
+
+test('extractSandboxConfig rejects empty array', async () => {
+  await assert.rejects(
+    extractSandboxConfig({ allowedRoots: [] }, 'test'),
+    SandboxViolationError,
+  )
+})
+
+test('extractSandboxConfig rejects missing transportConfig', async () => {
+  await assert.rejects(
+    extractSandboxConfig(undefined, 'test'),
+    SandboxViolationError,
+  )
+})
+
+// ── Glob operation type ─────────────────────────────────────────────────────
+
+test('assertInsideSandbox allows glob on ro root', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: root, access: 'ro' }] },
+      'test',
+    )
+    const resolved = await assertInsideSandbox(
+      join(root, 'sub'),
+      config,
+      'test',
+      'glob',
+    )
+    assert.ok(resolved.startsWith(root))
+  } finally {
+    await cleanup()
+  }
+})
+
+test('assertInsideSandbox allows glob on rw root', async () => {
+  const { root, cleanup } = await setupDir()
+  try {
+    const config = await extractSandboxConfig(
+      { allowedRoots: [{ path: root, access: 'rw' }] },
+      'test',
+    )
+    const resolved = await assertInsideSandbox(
+      join(root, 'sub'),
+      config,
+      'test',
+      'glob',
+    )
+    assert.ok(resolved.startsWith(root))
+  } finally {
+    await cleanup()
+  }
+})

--- a/worker/src/run/builtin-handlers/sandbox.ts
+++ b/worker/src/run/builtin-handlers/sandbox.ts
@@ -19,12 +19,36 @@ export type OperationType = 'read' | 'write' | 'glob'
 
 export type SandboxRoot = {
   path: string
-  kind?: SandboxRootKind
-  access?: SandboxRootAccess
+  kind: SandboxRootKind
+  access: SandboxRootAccess
 }
 
 export type SandboxConfig = {
   allowedRoots: SandboxRoot[]
+}
+
+const parseRootKind = (
+  value: unknown,
+  toolId: string,
+  rootPath: string,
+): SandboxRootKind => {
+  if (value === undefined) return 'dir'
+  if (value === 'dir' || value === 'file') return value
+  throw new SandboxViolationError(
+    `Tool ${toolId} allowedRoot "${rootPath}" kind must be 'dir' or 'file'.`,
+  )
+}
+
+const parseRootAccess = (
+  value: unknown,
+  toolId: string,
+  rootPath: string,
+): SandboxRootAccess => {
+  if (value === undefined) return 'rw'
+  if (value === 'ro' || value === 'rw') return value
+  throw new SandboxViolationError(
+    `Tool ${toolId} allowedRoot "${rootPath}" access must be 'ro' or 'rw'.`,
+  )
 }
 
 /**
@@ -89,10 +113,8 @@ export const extractSandboxConfig = async (
       )
     }
 
-    const kind: SandboxRootKind =
-      obj.kind === 'file' ? 'file' : 'dir'
-    const access: SandboxRootAccess =
-      obj.access === 'ro' ? 'ro' : 'rw'
+    const kind = parseRootKind(obj.kind, toolId, obj.path)
+    const access = parseRootAccess(obj.access, toolId, obj.path)
 
     let realPath: string
     try {

--- a/worker/src/run/builtin-handlers/sandbox.ts
+++ b/worker/src/run/builtin-handlers/sandbox.ts
@@ -1,4 +1,4 @@
-import { realpath } from 'node:fs/promises'
+import { realpath, lstat } from 'node:fs/promises'
 import { basename, dirname, resolve, sep } from 'node:path'
 
 /**
@@ -13,8 +13,18 @@ export class SandboxViolationError extends Error {
   }
 }
 
+export type SandboxRootKind = 'dir' | 'file'
+export type SandboxRootAccess = 'ro' | 'rw'
+export type OperationType = 'read' | 'write' | 'glob'
+
+export type SandboxRoot = {
+  path: string
+  kind?: SandboxRootKind
+  access?: SandboxRootAccess
+}
+
 export type SandboxConfig = {
-  allowedRoots: string[]
+  allowedRoots: SandboxRoot[]
 }
 
 /**
@@ -22,6 +32,9 @@ export type SandboxConfig = {
  * missing or empty — there is no implicit fallback root. Filesystem builtins
  * must opt in to a sandbox. Each allowed root is realpath'd so a symlinked
  * root cannot bypass the prefix check downstream.
+ *
+ * Backward-compatible: accepts legacy `string[]` entries and normalizes them
+ * to `SandboxRoot` objects with default `kind='dir'` and `access='rw'`.
  */
 export const extractSandboxConfig = async (
   transportConfig: unknown,
@@ -40,23 +53,74 @@ export const extractSandboxConfig = async (
     )
   }
 
-  const allowedRoots: string[] = []
+  const allowedRoots: SandboxRoot[] = []
   for (const entry of raw) {
-    if (typeof entry !== 'string' || entry.length === 0) {
+    if (typeof entry === 'string') {
+      // Legacy format: normalize to SandboxRoot with defaults
+      if (entry.length === 0) {
+        throw new SandboxViolationError(
+          `Tool ${toolId} allowedRoots must be non-empty strings.`,
+        )
+      }
+      try {
+        const real = await realpath(resolve(entry))
+        allowedRoots.push({ path: real, kind: 'dir', access: 'rw' })
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+          throw new SandboxViolationError(
+            `Tool ${toolId} allowedRoot "${entry}" does not exist.`,
+          )
+        }
+        throw err
+      }
+      continue
+    }
+
+    if (!entry || typeof entry !== 'object') {
       throw new SandboxViolationError(
-        `Tool ${toolId} allowedRoots must be non-empty strings.`,
+        `Tool ${toolId} allowedRoots entries must be strings or objects.`,
       )
     }
+
+    const obj = entry as Record<string, unknown>
+    if (typeof obj.path !== 'string' || obj.path.length === 0) {
+      throw new SandboxViolationError(
+        `Tool ${toolId} allowedRoots object entries must have a non-empty 'path' string.`,
+      )
+    }
+
+    const kind: SandboxRootKind =
+      obj.kind === 'file' ? 'file' : 'dir'
+    const access: SandboxRootAccess =
+      obj.access === 'ro' ? 'ro' : 'rw'
+
+    let realPath: string
     try {
-      allowedRoots.push(await realpath(resolve(entry)))
+      realPath = await realpath(resolve(obj.path))
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
         throw new SandboxViolationError(
-          `Tool ${toolId} allowedRoot "${entry}" does not exist.`,
+          `Tool ${toolId} allowedRoot "${obj.path}" does not exist.`,
         )
       }
       throw err
     }
+
+    if (kind === 'file') {
+      try {
+        const s = await lstat(realPath)
+        if (!s.isFile()) {
+          throw new SandboxViolationError(
+            `Tool ${toolId} allowedRoot "${obj.path}" kind is 'file' but path is not a file.`,
+          )
+        }
+      } catch (err) {
+        if (err instanceof SandboxViolationError) throw err
+        throw err
+      }
+    }
+
+    allowedRoots.push({ path: realPath, kind, access })
   }
 
   return { allowedRoots }
@@ -97,18 +161,40 @@ const realpathCandidate = async (candidate: string): Promise<string> => {
  * Resolve a candidate path (following symlinks) and ensure it sits inside one
  * of the allowed roots. Blocks `..` traversal AND symlink escape — both are
  * eliminated before the prefix check.
+ *
+ * Also enforces per-root `kind` (dir/file) and `access` (ro/rw) constraints
+ * based on the operation type.
  */
 export const assertInsideSandbox = async (
   candidate: string,
   sandbox: SandboxConfig,
   toolId: string,
+  operation?: OperationType,
 ): Promise<string> => {
   const resolved = await realpathCandidate(candidate)
+
   for (const root of sandbox.allowedRoots) {
-    const rootWithSep = root.endsWith(sep) ? root : `${root}${sep}`
-    if (resolved === root || resolved.startsWith(rootWithSep)) {
-      return resolved
+    const rootWithSep = root.path.endsWith(sep) ? root.path : `${root.path}${sep}`
+    const inside = resolved === root.path || resolved.startsWith(rootWithSep)
+    if (!inside) continue
+
+    // Enforce kind constraint
+    if (root.kind === 'file') {
+      if (resolved !== root.path) {
+        throw new SandboxViolationError(
+          `Tool ${toolId} rejected path "${candidate}" — root is a file, cannot access sub-paths.`,
+        )
+      }
     }
+
+    // Enforce access constraint
+    if (operation && root.access === 'ro' && operation === 'write') {
+      throw new SandboxViolationError(
+        `Tool ${toolId} rejected write to "${candidate}" — root is read-only.`,
+      )
+    }
+
+    return resolved
   }
 
   throw new SandboxViolationError(

--- a/worker/src/run/circuit-breaker.ts
+++ b/worker/src/run/circuit-breaker.ts
@@ -1,0 +1,27 @@
+export const CIRCUIT_BREAKER_THRESHOLD = 3
+
+export class ToolCircuitBreaker {
+  private _consecutiveErrors = new Map<string, number>()
+
+  recordSuccess(toolName: string): void {
+    this._consecutiveErrors.delete(toolName)
+  }
+
+  recordError(toolName: string): { tripped: boolean; count: number } {
+    const count = (this._consecutiveErrors.get(toolName) ?? 0) + 1
+    this._consecutiveErrors.set(toolName, count)
+    return { tripped: count >= CIRCUIT_BREAKER_THRESHOLD, count }
+  }
+
+  isTripped(toolName: string): boolean {
+    return (this._consecutiveErrors.get(toolName) ?? 0) >= CIRCUIT_BREAKER_THRESHOLD
+  }
+
+  trippedErrorMessage(toolName: string): string {
+    return `Tool "${toolName}" disabled after ${CIRCUIT_BREAKER_THRESHOLD} consecutive failures`
+  }
+
+  reset(): void {
+    this._consecutiveErrors.clear()
+  }
+}

--- a/worker/test/agentic-loop.test.ts
+++ b/worker/test/agentic-loop.test.ts
@@ -205,3 +205,151 @@ test('runAgenticLoop enforces the maxTokens budget', async () => {
   assert.equal(result.totalTokensUsed, 6)
   assert.deepEqual(exhausted, ['tokens'])
 })
+
+test('circuit breaker trips after 3 consecutive tool failures', async () => {
+  let toolCallCount = 0
+
+  const result = await runAgenticLoop({
+    budget: {
+      maxIterations: 6,
+      maxToolCalls: 6,
+      maxWallclockMs: 10_000,
+    },
+    callbacks: {
+      onIterationStart: async () => {},
+      onToolCallStart: async () => {},
+      onToolCallEnd: async () => {},
+      onTextDelta: async () => {},
+      onBudgetExhausted: async () => {},
+    },
+    executeTool: async () => {
+      toolCallCount += 1
+      return {
+        inputSummary: 'fail',
+        output: 'Error: something went wrong',
+        success: false,
+      }
+    },
+    initialMessages: [{ content: 'Run the tool.', role: 'user' }],
+    runInference: async (messages) => {
+      const toolCalls = messages.filter((m) => m.role === 'tool')
+      if (toolCalls.length < 4) {
+        return {
+          correlationId: 'corr-cb',
+          finishReason: 'tool-call',
+          invocations: [makeInvocation()],
+          model: 'gpt-5-mini',
+          outputText: '',
+          provider: 'openai',
+          requestId: 'req-cb',
+          toolCalls: [
+            {
+              arguments: { x: 1 },
+              toolCallId: `call_${toolCalls.length + 1}`,
+              toolName: 'failing_tool',
+            },
+          ],
+        }
+      }
+      return {
+        correlationId: 'corr-cb',
+        finishReason: 'stop',
+        invocations: [makeInvocation()],
+        model: 'gpt-5-mini',
+        outputText: 'Done.',
+        provider: 'openai',
+        requestId: 'req-cb-final',
+        toolCalls: [],
+      }
+    },
+    tools: [
+      {
+        description: 'A tool that always fails.',
+        inputSchema: {
+          properties: { x: { type: 'number' } },
+          required: ['x'],
+          type: 'object',
+        },
+        toolName: 'failing_tool',
+      },
+    ],
+  })
+
+  assert.equal(result.toolCallsUsed, 4)
+  assert.equal(result.finalText, 'Done.')
+})
+
+test('circuit breaker resets on success', async () => {
+  let toolCallCount = 0
+
+  const result = await runAgenticLoop({
+    budget: {
+      maxIterations: 6,
+      maxToolCalls: 6,
+      maxWallclockMs: 10_000,
+    },
+    callbacks: {
+      onIterationStart: async () => {},
+      onToolCallStart: async () => {},
+      onToolCallEnd: async () => {},
+      onTextDelta: async () => {},
+      onBudgetExhausted: async () => {},
+    },
+    executeTool: async () => {
+      toolCallCount += 1
+      // Fail twice, then succeed
+      return {
+        inputSummary: 'test',
+        output: toolCallCount <= 2 ? 'Error' : 'Success',
+        success: toolCallCount > 2,
+      }
+    },
+    initialMessages: [{ content: 'Run the tool.', role: 'user' }],
+    runInference: async (messages) => {
+      const toolCalls = messages.filter((m) => m.role === 'tool')
+      if (toolCalls.length < 5) {
+        return {
+          correlationId: 'corr-cb2',
+          finishReason: 'tool-call',
+          invocations: [makeInvocation()],
+          model: 'gpt-5-mini',
+          outputText: '',
+          provider: 'openai',
+          requestId: 'req-cb2',
+          toolCalls: [
+            {
+              arguments: { x: 1 },
+              toolCallId: `call_${toolCalls.length + 1}`,
+              toolName: 'flaky_tool',
+            },
+          ],
+        }
+      }
+      return {
+        correlationId: 'corr-cb2',
+        finishReason: 'stop',
+        invocations: [makeInvocation()],
+        model: 'gpt-5-mini',
+        outputText: 'Done.',
+        provider: 'openai',
+        requestId: 'req-cb2-final',
+        toolCalls: [],
+      }
+    },
+    tools: [
+      {
+        description: 'A tool that fails then succeeds.',
+        inputSchema: {
+          properties: { x: { type: 'number' } },
+          required: ['x'],
+          type: 'object',
+        },
+        toolName: 'flaky_tool',
+      },
+    ],
+  })
+
+  // 2 failures + 1 success resets + 3 more calls = 5 total, none tripped
+  assert.equal(result.toolCallsUsed, 5)
+  assert.equal(result.finalText, 'Done.')
+})

--- a/worker/test/circuit-breaker.test.ts
+++ b/worker/test/circuit-breaker.test.ts
@@ -1,0 +1,70 @@
+import { describe, test } from 'node:test'
+import assert from 'node:assert'
+import { ToolCircuitBreaker } from '../src/run/circuit-breaker.js'
+
+describe('ToolCircuitBreaker', () => {
+  test('starts with no errors recorded', () => {
+    const cb = new ToolCircuitBreaker()
+    assert.strictEqual(cb.isTripped('bash'), false)
+    assert.strictEqual(cb.isTripped('web_fetch'), false)
+  })
+
+  test('records success resets error count', () => {
+    const cb = new ToolCircuitBreaker()
+    cb.recordError('bash')
+    cb.recordError('bash')
+    cb.recordSuccess('bash')
+    assert.strictEqual(cb.isTripped('bash'), false)
+  })
+
+  test('trips after 3 consecutive errors', () => {
+    const cb = new ToolCircuitBreaker()
+    const r1 = cb.recordError('bash')
+    assert.strictEqual(r1.tripped, false)
+    assert.strictEqual(r1.count, 1)
+
+    const r2 = cb.recordError('bash')
+    assert.strictEqual(r2.tripped, false)
+    assert.strictEqual(r2.count, 2)
+
+    const r3 = cb.recordError('bash')
+    assert.strictEqual(r3.tripped, true)
+    assert.strictEqual(r3.count, 3)
+
+    assert.strictEqual(cb.isTripped('bash'), true)
+  })
+
+  test('tracks errors per tool independently', () => {
+    const cb = new ToolCircuitBreaker()
+    cb.recordError('bash')
+    cb.recordError('bash')
+    cb.recordError('web_fetch')
+    assert.strictEqual(cb.isTripped('bash'), false)
+    assert.strictEqual(cb.isTripped('web_fetch'), false)
+
+    cb.recordError('bash')
+    assert.strictEqual(cb.isTripped('bash'), true)
+    assert.strictEqual(cb.isTripped('web_fetch'), false)
+  })
+
+  test('reset clears all state', () => {
+    const cb = new ToolCircuitBreaker()
+    cb.recordError('bash')
+    cb.recordError('bash')
+    cb.recordError('bash')
+    assert.strictEqual(cb.isTripped('bash'), true)
+
+    cb.reset()
+    assert.strictEqual(cb.isTripped('bash'), false)
+  })
+
+  test('tripped error message includes tool name and threshold', () => {
+    const cb = new ToolCircuitBreaker()
+    cb.recordError('file_read')
+    cb.recordError('file_read')
+    cb.recordError('file_read')
+    const msg = cb.trippedErrorMessage('file_read')
+    assert.ok(msg.includes('file_read'))
+    assert.ok(msg.includes('3'))
+  })
+})


### PR DESCRIPTION
## Summary
- add a per-run tool circuit breaker for repeated tool failures
- add per-root sandbox kind/access handling for filesystem tools
- keep legacy string allowedRoots compatible while validating object root modes

Picked from the useful parts of #195/#200 and repaired against current main.

## Verification
- pnpm --filter @nessie/worker lint
- pnpm --filter @nessie/worker typecheck
- pnpm --filter @nessie/worker... build
- pnpm --filter @nessie/worker test
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build