### PR TITLE
Sync sandbox root manifest contract

### DIFF
--- a/docs/agent-tool-capabilities/05-sandbox-discovery.md
+++ b/docs/agent-tool-capabilities/05-sandbox-discovery.md
@@ -5,10 +5,18 @@
 Tool and sub-agent execution policy must include explicit filesystem constraints:
 
 ```ts
+type SandboxRoot =
+  | string
+  | {
+      path: string
+      kind?: 'dir' | 'file'
+      access?: 'ro' | 'rw'
+    }
+
 type SandboxPolicy = {
   type: 'allow-deny'
   allowOutsideReadOnly: boolean
-  allowedRoots: string[]             // e.g. ["/System/Volumes/Data/Projects"]
+  allowedRoots: SandboxRoot[]        // string roots are legacy dir/rw entries
   allowedCwd?: string[]             // command default and runtime cwd override allowlist
   deniedPaths?: string[]            // deny takes precedence
   env: {
@@ -31,8 +39,13 @@ type SandboxPolicy = {
 
 - Defaults should be strict:
   - deny by default outside configured execution roots unless explicitly listed.
-  - treat `write` as denied unless explicitly allowed in `allowedRoots`.
+  - treat `write` as denied unless the matching `allowedRoots` entry has `access: 'rw'`.
   - all external path reads must be denied or mapped read-only when `allowOutsideReadOnly = true`.
+- `allowedRoots` entries:
+  - legacy string entries normalize to `{ path, kind: 'dir', access: 'rw' }`.
+  - object entries may set `kind: 'dir' | 'file'`; missing `kind` defaults to `dir`.
+  - object entries may set `access: 'ro' | 'rw'`; missing `access` defaults to `rw`.
+  - invalid `kind` or `access` values must fail validation instead of widening permissions.
 - Sandbox policy can be inherited from role, then overridden by agent, then overridden by tool call config.
 - Enforcement points:
   - command/session spawn normalization

--- a/docs/nessie-toolset.example.json
+++ b/docs/nessie-toolset.example.json
@@ -17,7 +17,18 @@
     "defaultToolMode": "inherit",
     "defaultSandbox": {
       "allowOutsideReadOnly": true,
-      "allowedRoots": ["/System/Volumes/Data/.internal/projects/Projects"],
+      "allowedRoots": [
+        {
+          "path": "/System/Volumes/Data/.internal/projects/Projects",
+          "kind": "dir",
+          "access": "rw"
+        },
+        {
+          "path": "/System/Volumes/Data/.internal/projects/Projects/shared-readme.md",
+          "kind": "file",
+          "access": "ro"
+        }
+      ],
       "deniedPaths": ["/etc", "/System/Volumes/Data/.internal/secrets"],
       "env": {
         "allowVars": ["PATH", "HOME", "OLLAMA_HOST"],

--- a/docs/tool-registry-spec.md
+++ b/docs/tool-registry-spec.md
@@ -294,6 +294,14 @@ Supported file forms:
 Manifest schema:
 
 ```ts
+type SandboxRoot =
+  | string
+  | {
+      path: string;
+      kind?: 'dir' | 'file';
+      access?: 'ro' | 'rw';
+    };
+
 type NessieToolBundle = {
   apiVersion: 'toolset.nessie.io/v1';
   kind: 'NessieToolBundle';
@@ -313,7 +321,7 @@ type NessieToolBundle = {
     defaultToolMode: ToolGrantState;
     defaultSandbox?: {
       allowOutsideReadOnly?: boolean;
-      allowedRoots?: string[];
+      allowedRoots?: SandboxRoot[];
       deniedPaths?: string[];
       env?: {
         allowVars?: string[];

--- a/packages/connectors/src/types.ts
+++ b/packages/connectors/src/types.ts
@@ -72,10 +72,21 @@ const SandboxEnvSchema = z
   })
   .strict()
 
+const SandboxRootSchema = z.union([
+  z.string().min(1, 'allowedRoots entries must not be empty'),
+  z
+    .object({
+      path: z.string().min(1, 'allowedRoots.path must not be empty'),
+      kind: z.enum(['dir', 'file']).optional(),
+      access: z.enum(['ro', 'rw']).optional(),
+    })
+    .strict(),
+])
+
 const SandboxSchema = z
   .object({
     allowOutsideReadOnly: z.boolean().optional(),
-    allowedRoots: z.array(z.string()).optional(),
+    allowedRoots: z.array(SandboxRootSchema).optional(),
     deniedPaths: z.array(z.string()).optional(),
     env: SandboxEnvSchema.optional(),
   })
@@ -146,6 +157,7 @@ export const NessieToolBundleSchema = z
 
 export type NessieToolBundleSignature = z.infer<typeof SignatureSchema>
 export type NessieToolBundleMetadata = z.infer<typeof MetadataSchema>
+export type NessieToolBundleSandboxRoot = z.infer<typeof SandboxRootSchema>
 export type NessieToolBundleTool = z.infer<typeof ToolEntrySchema>
 export type NessieToolBundlePolicy = z.infer<typeof PolicySchema>
 export type NessieToolBundle = z.infer<typeof NessieToolBundleSchema>

--- a/packages/connectors/test/validate.test.ts
+++ b/packages/connectors/test/validate.test.ts
@@ -33,6 +33,60 @@ test('validateManifest accepts a well-formed bundle and reports absent signature
   }
 })
 
+test('validateManifest accepts sandbox roots with explicit kind and access', async () => {
+  const value = parseManifest(await readFixture('valid.json'), 'json') as Record<
+    string,
+    unknown
+  >
+  value.policy = {
+    defaultToolMode: 'inherit',
+    defaultSandbox: {
+      allowedRoots: [
+        '/tmp/legacy-root',
+        { path: '/tmp/read-only-config.json', kind: 'file', access: 'ro' },
+        { path: '/tmp/workspace', kind: 'dir', access: 'rw' },
+      ],
+    },
+  }
+
+  const result = validateManifest(value)
+
+  assert.equal(result.ok, true)
+  if (result.ok) {
+    assert.deepEqual(result.bundle.policy?.defaultSandbox?.allowedRoots, [
+      '/tmp/legacy-root',
+      { path: '/tmp/read-only-config.json', kind: 'file', access: 'ro' },
+      { path: '/tmp/workspace', kind: 'dir', access: 'rw' },
+    ])
+  }
+})
+
+test('validateManifest rejects sandbox roots with invalid kind or access', async () => {
+  const value = parseManifest(await readFixture('valid.json'), 'json') as Record<
+    string,
+    unknown
+  >
+  value.policy = {
+    defaultToolMode: 'inherit',
+    defaultSandbox: {
+      allowedRoots: [
+        { path: '/tmp/workspace', kind: 'directory', access: 'read' },
+      ],
+    },
+  }
+
+  const result = validateManifest(value)
+
+  assert.equal(result.ok, false)
+  if (!result.ok) {
+    const paths = result.errors.map((e) => e.path)
+    assert.ok(
+      paths.some((p) => p.includes('policy.defaultSandbox.allowedRoots')),
+      `expected allowedRoots errors, got ${JSON.stringify(paths)}`,
+    )
+  }
+})
+
 test('validateManifest rejects manifests missing a required field with field path', async () => {
   const value = parseManifest(await readFixture('missing-required.json'), 'json')
 


### PR DESCRIPTION
## Summary
- allow tool bundle sandbox roots to use the same string-or-object shape the worker now accepts
- document kind and access semantics for sandbox roots
- update the example toolset and validation tests

## Verification
- pnpm --filter @nessie/connectors lint
- pnpm --filter @nessie/connectors typecheck
- pnpm --filter @nessie/connectors test
- pnpm lint:markdown-structure
- pnpm lint
- pnpm typecheck
- pnpm test
- pnpm build